### PR TITLE
Feature/merge remove binary target

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,197 @@
+name: Build and Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    env:
+      WORKSPACE: "${{ github.workspace }}"
+      GIT_BRANCH: "${{ github.ref }}"
+      CURRENT_TAG: "${{ github.ref_name }}"
+      # Worker endpoints: consumed from GitHub organisation variables first.
+      # If the org variable is not set the value is an empty string; the probe
+      # step below falls back to the same hardcoded defaults that are baked into
+      # the mini-sdk (MiniAttesterConfig / Approov.m), keeping them in sync.
+      # Worker management (create / redeploy) logic is centralized in the
+      # core-service-layers-testing script, but invoked here when needed.
+      TESTING_REPLY_URL: ${{ vars.TESTING_REPLY_URL }}
+      TESTING_REPLY_URL_UNPROTECTED: ${{ vars.TESTING_REPLY_URL_UNPROTECTED }}
+      # Required for the redeploy script invocation on failure
+      CLOUDFLARE_API_TOKEN_WORKERS_DEV: ${{ secrets.CLOUDFLARE_API_TOKEN_WORKERS_DEV }}
+      CLOUDFLARE_ACCOUNT_ID_WORKERS_DEV: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_WORKERS_DEV }}
+      # iOS Mini-SDK configuration for Package.swift
+      APPROOV_USE_MINI_SDK: "1"
+      APPROOV_MINI_SDK_PATH: "../core-service-layers-testing/mini-sdk/ios"
+
+    steps:
+      # -----------------------------------------------------------------------
+      # 1. Checkout this repository
+      # -----------------------------------------------------------------------
+      - name: Set up Git
+        run: git config --global --add safe.directory '*'
+
+      - name: Checkout approov-service-ios-swift-asynchttpclient
+        uses: actions/checkout@v5
+        with:
+          path: approov-service-ios-swift-asynchttpclient
+
+      # -----------------------------------------------------------------------
+      # 2. Clone core-service-layers-testing as a sibling directory
+      #    Package.swift expects: ../core-service-layers-testing/...
+      #    so both repos must sit under the same parent ($GITHUB_WORKSPACE).
+      # -----------------------------------------------------------------------
+      - name: Checkout core-service-layers-testing
+        uses: actions/checkout@v5
+        with:
+          repository: approov/core-service-layers-testing
+          token: ${{ secrets.CORE_SERVICE_LAYERS_TESTING_PAT }}
+          path: core-service-layers-testing
+
+      # -----------------------------------------------------------------------
+      # 3. Verify worker endpoints (with auto-redeploy)
+      #
+      #    URLs are resolved with the following precedence (mirrors the mini-sdk
+      #    fallback logic in MiniAttesterConfig / Approov.m):
+      #      1. GitHub org variable  (TESTING_REPLY_URL / _UNPROTECTED)
+      #      2. Mini-SDK hardcoded defaults (replay.ivol.workers.dev / ...)
+      #
+      #    If the workers are unavailable, this step invokes the management
+      #    script in core-service-layers-testing to redeploy them.
+      # -----------------------------------------------------------------------
+      - name: Verify worker endpoints
+        run: |
+          # ── URL resolution ──────────────────────────────────────────────────
+          PROTECTED_URL="${TESTING_REPLY_URL:-https://replay.ivol.workers.dev}"
+          UNPROTECTED_URL="${TESTING_REPLY_URL_UNPROTECTED:-https://replay-unprotected.ivol.workers.dev}"
+          
+          echo "TESTING_REPLY_URL=$PROTECTED_URL"       >> "$GITHUB_ENV"
+          echo "TESTING_REPLY_URL_UNPROTECTED=$UNPROTECTED_URL" >> "$GITHUB_ENV"
+
+          # ── Probe function ──────────────────────────────────────────────────
+          probe_worker() {
+            local url="$1"
+            curl --silent --show-error --fail --max-time 10 \
+              -X POST "$url" \
+              -H "Content-Type: application/json" \
+              -d '{"check":"probe"}' | grep -q '"body"'
+          }
+
+          echo "==> Probing workers..."
+          if probe_worker "$PROTECTED_URL" && probe_worker "$UNPROTECTED_URL"; then
+            echo "    All workers are healthy."
+            exit 0
+          fi
+
+          echo "    WARNING: One or more workers are down. Attempting redeploy..."
+          
+          # ── Invoke redeploy script ──────────────────────────────────────────
+          # The script is in the sibling directory cloned in Step 2.
+          # It uses the CLOUDFLARE_* env variables defined at the job level.
+          ./core-service-layers-testing/cloudflare-workers/redeploy-workers.sh
+
+          echo "==> Verifying after redeploy..."
+          # Try up to 3 times with a 5s delay between attempts
+          for i in {1..3}; do
+            if probe_worker "$PROTECTED_URL" && probe_worker "$UNPROTECTED_URL"; then
+              echo "    Workers successfully restored."
+              exit 0
+            fi
+            echo "    Waiting for propagation (attempt $i/3)..."
+            sleep 5
+          done
+
+          echo "ERROR: Workers are still unreachable after redeployment effort."
+          exit 1
+
+      # -----------------------------------------------------------------------
+      # 5. Build and run tests
+      #    Swift is invoked from inside the checked-out service directory.
+      #    The mini-sdk is already available via the sibling path wired into
+      #    Package.swift — no extra configuration needed here.
+      # -----------------------------------------------------------------------
+      - name: Build and Test (SwiftPM)
+        working-directory: approov-service-ios-swift-asynchttpclient
+        env:
+          TESTING_REPLY_URL: ${{ env.TESTING_REPLY_URL }}
+          TESTING_REPLY_URL_UNPROTECTED: ${{ env.TESTING_REPLY_URL_UNPROTECTED }}
+        run: |
+          set -o pipefail
+          swift test --verbose 2>&1 | tee test_output.txt
+
+      # -----------------------------------------------------------------------
+      # 6. Print test summary
+      #    Parses the Swift test output captured in the previous step.
+      # -----------------------------------------------------------------------
+      - name: Print test summary
+        if: always()
+        working-directory: approov-service-ios-swift-asynchttpclient
+        run: |
+          python3 - <<'EOF'
+          import os, sys, re
+
+          PASS  = "\u2705"
+          FAIL  = "\u274c"
+          SKIP  = "\u23ed\ufe0f"
+
+          output_path = "test_output.txt"
+          if not os.path.exists(output_path):
+              print("No test output found.")
+              sys.exit(1)
+
+          with open(output_path, "r") as f:
+              lines = f.readlines()
+
+          # Regex for Swift/XCTest output:
+          # Test Case '-[Suite.TestClass testName]' passed (0.123 seconds).
+          test_re = re.compile(r"Test Case '-\[(?P<suite>[^. ]+)\.(?P<class>[^ ]+) (?P<name>[^\]]+)\]' (?P<status>passed|failed) \((?P<time>[0-9.]+) seconds\)")
+          
+          results = []
+          for line in lines:
+              match = test_re.search(line)
+              if match:
+                  results.append({
+                      "name": match.group("name"),
+                      "class": match.group("class"),
+                      "status": match.group("status"),
+                      "time": float(match.group("time"))
+                  })
+
+          if not results:
+              print("No tests were detected in the output.")
+              # If we saw "0 tests passed" in the log, let's look for why.
+              sys.exit(1)
+
+          total = len(results)
+          passed = sum(1 for r in results if r["status"] == "passed")
+          failed = total - passed
+          overall_ok = (failed == 0)
+
+          # ── Console output ──────────────────────────────────────────────────
+          icon = PASS if overall_ok else FAIL
+          print()
+          print(f"{'='*70}")
+          print(f"  {icon}  Swift Test Summary  |  {passed}/{total} passed  |  {failed} failed")
+          print(f"{'='*70}")
+          for r in results:
+              print(f"  {PASS if r['status'] == 'passed' else FAIL}  {r['name']:<55} ({r['time']:.3f}s)")
+          print()
+
+          # ── GitHub Job Summary (markdown) ───────────────────────────────────
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+          if summary_path:
+              with open(summary_path, "a") as md:
+                  badge = "\U0001f7e2 PASSED" if overall_ok else "\U0001f534 FAILED"
+                  md.write(f"### Swift Tests &nbsp; {badge}\n\n")
+                  md.write(f"> **{passed} passed** &nbsp;|&nbsp; **{failed} failed** &nbsp;|&nbsp; **{total} total**\n\n")
+                  md.write("| Status | Test Case | Time |\n")
+                  md.write("|--------|-----------|-----:|\n")
+                  for r in results:
+                      icon = "\U0001f7e2" if r["status"] == "passed" else "\U0001f534"
+                      md.write(f"| {icon} | `{r['name']}` | {r['time']:.3f}s |\n")
+
+          sys.exit(0 if overall_ok else 1)
+          EOF

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -205,42 +205,45 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Extract and Verify Version
+      - name: Extract Version from CHANGELOG
         id: get-version
         run: |
-          CHANGELOG_VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || true
-          if [ -z "$CHANGELOG_VERSION" ]; then
+          VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || true
+          if [ -z "$VERSION" ]; then
             echo "::error::Could not find a version header (## [x.y.z]) in CHANGELOG.md"
             exit 1
           fi
-          
-          SWIFT_VERSION=$(grep -oE 'approov-service-asynchttpclient/[0-9]+\.[0-9]+\.[0-9]+' Sources/ApproovAsyncHTTPClient/ApproovService.swift | cut -d/ -f2) || true
-          if [ -z "$SWIFT_VERSION" ]; then
-            echo "::error::Could not find a version pattern (approov-service-asynchttpclient/x.y.z) in ApproovService.swift"
-            exit 1
-          fi
-
-          if [ "$CHANGELOG_VERSION" != "$SWIFT_VERSION" ]; then
-            echo "::error::Version mismatch: CHANGELOG.md ($CHANGELOG_VERSION) does not match ApproovService.swift ($SWIFT_VERSION)"
-            exit 1
-          fi
-
-          echo "VERSION=$CHANGELOG_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Validated version is: $CHANGELOG_VERSION"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version extracted from CHANGELOG.md is: $VERSION"
 
       - name: Create and Push Tag
         run: |
           VERSION="${{ steps.get-version.outputs.VERSION }}"
           
-          # Check if tag already exists
+          # Check if tag already exists on remote
           if git fetch origin "refs/tags/$VERSION" --quiet 2>/dev/null; then
             echo "Tag $VERSION already exists. Skipping tagging."
             exit 0
           fi
           
-          echo "Tag $VERSION does not exist. Creating and pushing..."
+          echo "Tag $VERSION does not exist. Verifying dev placeholder..."
+          FILE="Sources/ApproovAsyncHTTPClient/ApproovService.swift"
+          if ! grep -q 'approov-service-asynchttpclient/dev' "$FILE"; then
+            echo "::error::Could not find 'approov-service-asynchttpclient/dev' in $FILE"
+            exit 1
+          fi
+
+          echo "Replacing 'dev' with '$VERSION' in $FILE..."
+          perl -pi -e "s|approov-service-asynchttpclient/dev|approov-service-asynchttpclient/$VERSION|g" "$FILE"
+          
+          echo "Configuring git and committing release modifications..."
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Release version $VERSION"
+          
+          echo "Creating and pushing tag $VERSION..."
           git tag "$VERSION"
           git push origin "$VERSION"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -236,9 +236,10 @@ jobs:
             exit 1
           fi
 
-          echo "Replacing 'dev' with '$VERSION' in $FILE..."
+          echo "Replacing 'dev' with '$VERSION' in $FILE and Package.swift..."
           perl -pi -e "s|approov-service-asynchttpclient/dev|approov-service-asynchttpclient/$VERSION|g" "$FILE"
-          
+          perl -pi -e "s|releaseTAG = \"dev\"|releaseTAG = \"$VERSION\"|g" Package.swift
+
           echo "Configuring git and committing release modifications..."
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -195,3 +195,52 @@ jobs:
 
           sys.exit(0 if overall_ok else 1)
           EOF
+
+  tag-release:
+    needs: build-and-test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Extract and Verify Version
+        id: get-version
+        run: |
+          CHANGELOG_VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || true
+          if [ -z "$CHANGELOG_VERSION" ]; then
+            echo "::error::Could not find a version header (## [x.y.z]) in CHANGELOG.md"
+            exit 1
+          fi
+          
+          SWIFT_VERSION=$(grep -oE 'approov-service-asynchttpclient/[0-9]+\.[0-9]+\.[0-9]+' Sources/ApproovAsyncHTTPClient/ApproovService.swift | cut -d/ -f2) || true
+          if [ -z "$SWIFT_VERSION" ]; then
+            echo "::error::Could not find a version pattern (approov-service-asynchttpclient/x.y.z) in ApproovService.swift"
+            exit 1
+          fi
+
+          if [ "$CHANGELOG_VERSION" != "$SWIFT_VERSION" ]; then
+            echo "::error::Version mismatch: CHANGELOG.md ($CHANGELOG_VERSION) does not match ApproovService.swift ($SWIFT_VERSION)"
+            exit 1
+          fi
+
+          echo "VERSION=$CHANGELOG_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Validated version is: $CHANGELOG_VERSION"
+
+      - name: Create and Push Tag
+        run: |
+          VERSION="${{ steps.get-version.outputs.VERSION }}"
+          
+          # Check if tag already exists
+          if git fetch origin "refs/tags/$VERSION" --quiet 2>/dev/null; then
+            echo "Tag $VERSION already exists. Skipping tagging."
+            exit 0
+          fi
+          
+          echo "Tag $VERSION does not exist. Creating and pushing..."
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,6 +3,7 @@ name: Build and Test
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -196,9 +197,76 @@ jobs:
           sys.exit(0 if overall_ok else 1)
           EOF
 
-  tag-release:
+  # ---------------------------------------------------------------------------
+  # Release placeholder check (verification ONLY — never tags).
+  #
+  # On every push / PR this asserts that:
+  #   - CHANGELOG.md has a top version header (## [x.y.z]); and
+  #   - the "dev" release placeholders are present, so branches cut from main
+  #     inherit them: Package.swift releaseTAG = "dev", every root .podspec
+  #     s.version = "dev", and the setUserProperty telemetry string approov-service-asynchttpclient/dev.
+  # Tagging is a SEPARATE, manual step (the release job below), so any issue
+  # found after merge but before tagging can still be fixed on main first.
+  # ---------------------------------------------------------------------------
+  verify-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Verify CHANGELOG entry and dev placeholders
+        run: |
+          set -uo pipefail
+          VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || true
+          if [ -z "$VERSION" ]; then
+            echo "::error::No version header (## [x.y.z]) found in CHANGELOG.md"
+            exit 1
+          fi
+          echo "CHANGELOG top version: $VERSION"
+          fail=0
+
+          if ! grep -qF 'releaseTAG = "dev"' Package.swift; then
+            echo "::error::Package.swift is missing the releaseTAG = \"dev\" placeholder (must stay in main)"
+            grep -nE 'releaseTAG[[:space:]]*=' Package.swift || true
+            fail=1
+          fi
+
+          SRC="Sources/ApproovAsyncHTTPClient/ApproovService.swift"
+          if ! grep -qF "approov-service-asynchttpclient/dev" "$SRC"; then
+            echo "::error::$SRC is missing the approov-service-asynchttpclient/dev telemetry placeholder (must stay in main)"
+            grep -nE 'setUserProperty' "$SRC" || true
+            fail=1
+          fi
+
+          for p in *.podspec; do
+            [ -e "$p" ] || continue
+            if ! grep -qE '\.version[[:space:]]*=[[:space:]]*"dev"' "$p"; then
+              echo "::error::$p is missing the s.version = \"dev\" placeholder (must stay in main)"
+              grep -nE '\.version[[:space:]]*=' "$p" || true
+              fail=1
+            fi
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Release placeholders missing. main must keep the dev placeholders so branches inherit them; the release job stamps them at tag time."
+            exit 1
+          fi
+          echo "OK: CHANGELOG version $VERSION present and dev placeholders intact. Tagging is manual (Actions -> Release)."
+
+  # ---------------------------------------------------------------------------
+  # Manual release (workflow_dispatch ONLY — the single place that tags).
+  #
+  # Trigger from the Actions tab against main once main is known good. Gated on
+  # build-and-test so a release never tags failing code. It stamps the CHANGELOG
+  # version in lock-step into the dev placeholders (Package.swift releaseTAG,
+  # every root .podspec s.version, and the approov-service-asynchttpclient/dev telemetry string),
+  # commits "Release version <x.y.z>", and tags THAT commit. main keeps the dev
+  # placeholders (the release commit is not pushed to main, only the tag ref);
+  # the tag carries the stamped version. Skipped if the tag already exists.
+  # ---------------------------------------------------------------------------
+  release:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     needs: build-and-test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -219,32 +287,46 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version extracted from CHANGELOG.md is: $VERSION"
 
-      - name: Create and Push Tag
+      - name: Stamp version, commit and tag
         run: |
+          set -uo pipefail
           VERSION="${{ steps.get-version.outputs.VERSION }}"
-          
-          # Check if tag already exists on remote
+
           if git fetch origin "refs/tags/$VERSION" --quiet 2>/dev/null; then
             echo "Tag $VERSION already exists. Skipping tagging."
             exit 0
           fi
-          
-          echo "Tag $VERSION does not exist. Verifying dev placeholder..."
-          FILE="Sources/ApproovAsyncHTTPClient/ApproovService.swift"
-          if ! grep -q 'approov-service-asynchttpclient/dev' "$FILE"; then
-            echo "::error::Could not find 'approov-service-asynchttpclient/dev' in $FILE"
+
+          SRC="Sources/ApproovAsyncHTTPClient/ApproovService.swift"
+          if ! grep -qF "approov-service-asynchttpclient/dev" "$SRC"; then
+            echo "::error::Could not find 'approov-service-asynchttpclient/dev' placeholder in $SRC"
             exit 1
           fi
 
-          echo "Replacing 'dev' with '$VERSION' in $FILE and Package.swift..."
-          perl -pi -e "s|approov-service-asynchttpclient/dev|approov-service-asynchttpclient/$VERSION|g" "$FILE"
+          echo "Stamping version $VERSION into manifests and telemetry..."
+          perl -pi -e "s|approov-service-asynchttpclient/dev|approov-service-asynchttpclient/$VERSION|g" "$SRC"
           perl -pi -e "s|releaseTAG = \"dev\"|releaseTAG = \"$VERSION\"|g" Package.swift
+          for PODSPEC in *.podspec; do
+            [ -e "$PODSPEC" ] || continue
+            echo "Stamping version $VERSION into $PODSPEC..."
+            perl -pi -e "s|(\bs(?:pec)?\.version\s*=\s*['\"])dev(['\"])|\${1}$VERSION\${2}|g" "$PODSPEC"
+          done
 
-          echo "Configuring git and committing release modifications..."
+          # Defensive: refuse to tag if any dev placeholder survived.
+          leftover=0
+          grep -q 'releaseTAG = "dev"' Package.swift && leftover=1
+          grep -qF "approov-service-asynchttpclient/dev" "$SRC" && leftover=1
+          for PODSPEC in *.podspec; do
+            [ -e "$PODSPEC" ] || continue
+            grep -Eq 's\.version[[:space:]]*=[[:space:]]*"dev"' "$PODSPEC" && leftover=1
+          done
+          if [ "$leftover" -ne 0 ]; then
+            echo "::error::A dev placeholder was not replaced; aborting tag."
+            exit 1
+          fi
+
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Release version $VERSION"
-          
-          echo "Creating and pushing tag $VERSION..."
           git tag "$VERSION"
           git push origin "$VERSION"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .swiftpm
 Package.resolved
 .DS_Store
+.build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
+
+## [3.5.4] - 2026-06-13
+
+### Added
+- Completed full integration of Approov service layer v3 features: service mutator, bypass mode, trace ID, fallback token, secure string/query parameter substitutions, HTTP message signing (RFC 9421 signature builders and default request signers), and dynamic TLS pinning.
+- Added localized testing framework with a full 35-test suite utilizing the native Mini-SDK.
+- Excluded vendored message signing license files from the target build source to prevent SwiftPM warnings.
+
+### Changed
+- Refactored `ApproovService` to handle multi-threaded state access safely with locks.
+- Changed Package.swift to swift-tools-version 5.8 with support for structured headers, exact SDK dependencies, and conditional local Mini-SDK path setup.
+- Updated dynamic pinning to execute `Approov.getPins("public-key-sha256")` exactly once per handshake.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - Updated dynamic pinning to execute `Approov.getPins("public-key-sha256")` exactly once per handshake.
 
 ### Fixed
-- Pinning now matches Approov pins against the operating-system-validated certificate path rather than the raw chain presented by the peer. Previously, extra certificates supplied by the server that were not part of the validated trust path were still considered during pin matching, which could allow an attacker holding any CA-trusted certificate for the host to append the legitimate pinned certificate as a decoy and defeat pinning.
 - Documented the dynamic pinning update model in `REFERENCE.md`: pins are enforced per TLS handshake and apply immediately to all new connections, while connections already pooled under a previous pin set are re-pinned when they cycle.
 - Body digest computation for the `EventLoopFuture` (`HTTPClient.Request`) API now buffers multi-chunk in-memory bodies in full; previously the `signRequest` path retained only the final chunk, producing an incorrect `Content-Digest`.
 - One-shot and chunked streaming request bodies are now skipped for body-digest computation rather than being consumed or partially digested, so streaming uploads are no longer corrupted and signing proceeds without a body digest. Body extraction for the synchronous API is consolidated into a single shared implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,12 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - One-shot and chunked streaming request bodies are now skipped for body-digest computation rather than being consumed or partially digested, so streaming uploads are no longer corrupted and signing proceeds without a body digest. Body extraction for the synchronous API is consolidated into a single shared implementation.
 - `setBodyDigestConfig(nil, required:)` now fully disables body-digest generation; previously a digest algorithm configured earlier (including the default factory's SHA-256) persisted and digests continued to be generated.
 - Closed a race in `ApproovHTTPClient.Task` where a `cancel()` arriving while the request was being set up could be lost, allowing the request to execute uncancelled. The wrapped task is now stored and re-checked for cancellation under a single lock.
+- `fetchToken`, `fetchSecureString`, `fetchCustomJWT`, and `precheck` now guarantee that only `ApproovError` escapes: an error thrown by a custom service mutator is wrapped as `ApproovError.permanentError`, matching the documented throwing contract.
+- A message signature returned by the SDK that cannot be base64-decoded is now treated as a real error and propagated, instead of being silently swallowed by the "signature unavailable" silent-fallback path (which now applies only when the SDK returns no signature at all).
+- Invalid exclusion URL regular expressions passed to `addExclusionURLRegex` are now logged at error level (the exclusion is not registered), rather than being discarded with only a debug-level message.
+- Message signing now uses `replaceOrAdd` for the `Signature`, `Signature-Input`, `Signature-Base-Digest`, and `Content-Digest` headers so that re-processing a request cannot emit duplicate header lines.
+- RFC 9421 derived `@path` / `@request-target` components now use the on-wire percent-encoded path rather than the percent-decoded `URL.path`, so the server reconstructs the same signature base.
+- Logging now distinguishes "service layer not initialized" from "initialized in bypass mode (empty config)" when an Approov-dependent method is invoked while the SDK is inactive.
+
+### Documentation
+- `REFERENCE.md`: documented that automatic (`bindHeader`) and manual (`setDataHashInToken`) token binding must not be mixed, that `precheck()` is intended for development-time verification (and throws `ApproovError`), and that the legacy `updateRequest(url:headers:)` overload assumes `GET` with no body.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 ### Changed
 - Refactored `ApproovService` to handle multi-threaded state access safely with locks.
 - Changed Package.swift to swift-tools-version 5.8 with support for structured headers, exact SDK dependencies, and conditional local Mini-SDK path setup.
+- `Package.swift` `releaseTAG` is now a `dev` placeholder, stamped with the release version by the `tag-release` CI job at tag time (was a hardcoded literal), keeping it in lock-step with the runtime user-property string.
 - Updated dynamic pinning to execute `Approov.getPins("public-key-sha256")` exactly once per handshake.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,11 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - Refactored `ApproovService` to handle multi-threaded state access safely with locks.
 - Changed Package.swift to swift-tools-version 5.8 with support for structured headers, exact SDK dependencies, and conditional local Mini-SDK path setup.
 - Updated dynamic pinning to execute `Approov.getPins("public-key-sha256")` exactly once per handshake.
+
+### Fixed
+- Pinning now matches Approov pins against the operating-system-validated certificate path rather than the raw chain presented by the peer. Previously, extra certificates supplied by the server that were not part of the validated trust path were still considered during pin matching, which could allow an attacker holding any CA-trusted certificate for the host to append the legitimate pinned certificate as a decoy and defeat pinning.
+- Documented the dynamic pinning update model in `REFERENCE.md`: pins are enforced per TLS handshake and apply immediately to all new connections, while connections already pooled under a previous pin set are re-pinned when they cycle.
+- Body digest computation for the `EventLoopFuture` (`HTTPClient.Request`) API now buffers multi-chunk in-memory bodies in full; previously the `signRequest` path retained only the final chunk, producing an incorrect `Content-Digest`.
+- One-shot and chunked streaming request bodies are now skipped for body-digest computation rather than being consumed or partially digested, so streaming uploads are no longer corrupted and signing proceeds without a body digest. Body extraction for the synchronous API is consolidated into a single shared implementation.
+- `setBodyDigestConfig(nil, required:)` now fully disables body-digest generation; previously a digest algorithm configured earlier (including the default factory's SHA-256) persisted and digests continued to be generated.
+- Closed a race in `ApproovHTTPClient.Task` where a `cancel()` arriving while the request was being set up could be lost, allowing the request to execute uncancelled. The wrapped task is now stored and re-checked for cancellation under a single lock.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - Updated dynamic pinning to execute `Approov.getPins("public-key-sha256")` exactly once per handshake.
 
 ### Fixed
+- Message signing now fully conforms to the cross-layer fail-open policy (core-project-approov#564): a signature-base build failure and a `Signature`/`Signature-Input` serialization failure now log at error level and proceed **unsigned** instead of aborting the request, matching the existing install/account/base64/ASN.1 fail-open paths. Only a required body digest that cannot be generated and an unsupported algorithm still fail closed.
 - Documented the dynamic pinning update model in `REFERENCE.md`: pins are enforced per TLS handshake and apply immediately to all new connections, while connections already pooled under a previous pin set are re-pinned when they cycle.
 - Body digest computation for the `EventLoopFuture` (`HTTPClient.Request`) API now buffers multi-chunk in-memory bodies in full; previously the `signRequest` path retained only the final chunk, producing an incorrect `Content-Digest`.
 - One-shot and chunked streaming request bodies are now skipped for body-digest computation rather than being consumed or partially digested, so streaming uploads are no longer corrupted and signing proceeds without a body digest. Body extraction for the synchronous API is consolidated into a single shared implementation.

--- a/Package.swift
+++ b/Package.swift
@@ -49,9 +49,11 @@ var packageTargets: [Target] = [
             .product(name: "AsyncHTTPClient", package: "async-http-client"),
             .product(name: "NIOCore", package: "swift-nio"),
             .product(name: "NIOEmbedded", package: "swift-nio"),
+            .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
             .product(name: "Approov", package: approovPackageName),
             .product(name: "RawStructuredFieldValues", package: "swift-http-structured-headers")
-        ]
+        ],
+        exclude: ["util/sig/LICENSE"]
     )
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,10 @@
 import Foundation
 import PackageDescription
 
-// The release tag for this version of ApproovAsyncHTTPClient
-let releaseTAG = "3.5.4"
+// The release tag for this version of ApproovAsyncHTTPClient — "dev" for local/CI builds;
+// replaced with the CHANGELOG version by the tag-release CI job at release time (in lock-step
+// with the runtime user-property string).
+let releaseTAG = "dev"
 // SDK package version
 let sdkVersion: Version = "3.5.3"
 // NOTE: The useMiniSDK flag and miniSDKPath are used for local and CI automated testing only.

--- a/Package.swift
+++ b/Package.swift
@@ -1,40 +1,84 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+import Foundation
 import PackageDescription
 
-let approovSDKVersion = "3.5.3"
-let asyncHTTPClientVersion: Version = Version(1, 10, 2)
+// The release tag for this version of ApproovAsyncHTTPClient
+let releaseTAG = "3.5.4"
+// SDK package version
+let sdkVersion: Version = "3.5.3"
+// NOTE: The useMiniSDK flag and miniSDKPath are used for local and CI automated testing only.
+// They are not included or used in production releases, which depend exclusively on the real approov-ios-sdk.
+let useMiniSDK = ProcessInfo.processInfo.environment["APPROOV_USE_MINI_SDK"] == "1"
+let miniSDKPath = ProcessInfo.processInfo.environment["APPROOV_MINI_SDK_PATH"] ?? ""
+
+let approovPackageName = useMiniSDK ? "mini-sdk-ios" : "approov-ios-sdk"
+let packagePlatforms: [SupportedPlatform] = useMiniSDK
+    ? [
+        .iOS(.v13),
+        .macOS(.v13),
+    ]
+    : [
+        .iOS(.v13),
+    ]
+
+var packageDependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/approov/async-http-client", from: "1.10.2"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.38.0"),
+    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.1"),
+    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.0"),
+    .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.10.0"),
+    .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
+    .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
+    .package(url: "https://github.com/apple/swift-http-structured-headers.git", from: "1.0.0"),
+]
+
+if useMiniSDK {
+    // Local Mini-SDK dependency for testing purposes only.
+    packageDependencies.append(.package(name: "mini-sdk-ios", path: miniSDKPath))
+} else {
+    // Production release dependency on the official Approov iOS SDK.
+    packageDependencies.append(.package(url: "https://github.com/approov/approov-ios-sdk.git", exact: sdkVersion))
+}
+
+var packageTargets: [Target] = [
+    .target(
+        name: "ApproovAsyncHTTPClient",
+        dependencies: [
+            .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            .product(name: "NIOCore", package: "swift-nio"),
+            .product(name: "NIOEmbedded", package: "swift-nio"),
+            .product(name: "Approov", package: approovPackageName),
+            .product(name: "RawStructuredFieldValues", package: "swift-http-structured-headers")
+        ]
+    )
+]
+
+if useMiniSDK {
+    // Test target for verifying the package locally/CI using the mock Mini-SDK.
+    packageTargets.append(
+        .testTarget(
+            name: "ApproovAsyncHTTPClientMiniSDKTests",
+            dependencies: [
+                "ApproovAsyncHTTPClient",
+                .product(name: "Approov", package: "mini-sdk-ios"),
+                .product(name: "MiniSDKTestSupport", package: "mini-sdk-ios")
+            ],
+            path: "Tests/ApproovAsyncHTTPClientMiniSDKTests"
+        )
+    )
+}
 
 let package = Package(
     name: "ApproovAsyncHTTPClient",
-    platforms: [.iOS(.v13)],
+    platforms: packagePlatforms,
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "ApproovAsyncHTTPClient",
-            targets: ["ApproovAsyncHTTPClient"])
+            targets: ["ApproovAsyncHTTPClient"]
+        )
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/approov/async-http-client", from: "1.10.2"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.38.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.1"),
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.0"),
-        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.10.0"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
-        .package(url: "https://github.com/approov/approov-ios-sdk.git", from: "3.5.3")
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
-            name: "ApproovAsyncHTTPClient",
-            dependencies: [
-                .product(name: "AsyncHTTPClient", package: "async-http-client"),
-                .product(name: "Approov", package: "approov-ios-sdk")
-            ]
-        ),
-    ]
+    dependencies: packageDependencies,
+    targets: packageTargets
 )

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
 # Approov Service for AsyncHTTPClient
 
+![Swift](https://img.shields.io/badge/Swift-5.8%2B-F05138?logo=swift&logoColor=white)
+![iOS](https://img.shields.io/badge/iOS-13%2B-000000?logo=apple&logoColor=white)
+![SwiftPM](https://img.shields.io/github/v/tag/approov/approov-service-ios-swift-asynchttpclient?logo=swift&logoColor=white&label=SwiftPM&color=F05138)
+![Message Signing](https://img.shields.io/badge/Message%20Signing-RFC%209421-1f6feb)
+![Build](https://github.com/approov/approov-service-ios-swift-asynchttpclient/actions/workflows/build_and_test.yml/badge.svg)
+
 A wrapper for the [Approov SDK](https://github.com/approov/approov-ios-sdk) to enable easy integration when using [`AsyncHTTPClient`](https://github.com/swift-server/async-http-client) for making the API calls that you wish to protect with Approov. In order to use this you will need a trial or paid [Approov](https://www.approov.io) account.
 
-Please see the [Quickstart](https://github.com/approov/quickstart-ios-swift-asynchttpclient) for example integration.
+This page provides the steps for integrating Approov into your app. Additionally, a step-by-step tutorial guide using our [Shapes App Example](https://github.com/approov/quickstart-ios-swift-asynchttpclient/blob/master/SHAPES-EXAMPLE.md) is also available.
 
-## Swift Package Manager Import
+To follow this guide you should have received an onboarding email for a trial or paid Approov account.
 
-When adding this package with Swift Package Manager, import the module as:
+## ADDING APPROOV SERVICE DEPENDENCY
+The Approov integration is available via the [Swift Package Manager](https://www.swift.org/package-manager/). This allows inclusion into the project by adding a dependency on the `ApproovAsyncHTTPClient` package in Xcode. In the search box of the add packages dialog, enter the URL of the git repository `https://github.com/approov/approov-service-ios-swift-asynchttpclient.git` and choose the version you wish to use.
+
+The `ApproovAsyncHTTPClient` package is an open-source wrapper layer that allows you to easily use Approov with AsyncHTTPClient. It has a further dependency on the closed-source [`Approov` iOS SDK](https://github.com/approov/approov-ios-sdk).
+
+Once added, import the module wherever you use it:
 
 ```swift
 import ApproovAsyncHTTPClient
@@ -15,10 +26,98 @@ import Approov
 
 The primary client type is `ApproovHTTPClient`, while `ApproovService` provides lower-level configuration and direct SDK helper methods.
 
-# Reference
+## INITIALIZING APPROOV SERVICE
+In order to use the `ApproovService` you must initialize it when your app is created, before constructing any `ApproovHTTPClient`. Initialization can fail (bad config, SDK error) and `initialize(config:)` is a throwing call, so wrap it in `do/catch` and make sure your app survives a failure rather than crashing:
 
-Please see the [REFERENCE.md](REFERENCE.md) for more information on the Approov Service for AsyncHTTPClient.
+```swift
+import ApproovAsyncHTTPClient
+import Foundation
+import os
 
-# Usage
+let log = Logger(subsystem: "com.yourcompany.yourapp", category: "approov")
 
-Please see the [USAGE.md](USAGE.md) for more information on how to use this wrapper.
+// An app-generated id used to correlate this install/session across your own app logs and
+// your backend. Use a UUID, or any session/user identifier you already have — it is NOT an
+// Approov secret.
+let correlationId = UUID().uuidString
+
+do {
+    try ApproovService.initialize(config: "<enter-your-config-string-here>")
+    // Confirm Approov is actually active before treating it as enabled, then log identifiers
+    // for correlation / observability.
+    if ApproovService.isApproovEnabled() {
+        let deviceID = ApproovService.getDeviceID() ?? "unknown"
+        log.info("Approov initialized; deviceID=\(deviceID, privacy: .public) session=\(correlationId, privacy: .public)")
+    } else {
+        log.notice("Approov initialized in bypass mode (no protection); session=\(correlationId, privacy: .public)")
+    }
+} catch {
+    // Initialization failed — log it and continue UNPROTECTED so the app still works.
+    // Re-initializing with an empty config string enters bypass mode (initialized, but no
+    // Approov token injection, pinning, or secret substitution).
+    log.error("Approov init failed (session=\(correlationId, privacy: .public)); continuing unprotected: \(String(describing: error), privacy: .public)")
+    try? ApproovService.initialize(config: "")
+}
+```
+
+The `<enter-your-config-string-here>` is a custom string that configures your Approov account access. This will have been provided in your Approov onboarding email.
+
+On success the example logs the Approov **device ID** (`getDeviceID()`) and an **app-generated session/correlation id** (a UUID, or any session/user identifier you use) so a given install can be correlated across your app logs, backend, and the Approov [Live Metrics](https://approov.io/docs/latest/approov-usage-documentation/#metrics-graphs). If initialization fails, the example re-initializes with an empty config so the app keeps working — but those requests go out **without Approov protection**, so treat the backend as the enforcement point.
+
+## USING APPROOV SERVICE
+Once `ApproovService` is initialized, create an `ApproovHTTPClient` and use it as you would the standard `AsyncHTTPClient` `HTTPClient`. The wrapper automatically applies Approov token fetching, secure string substitution, message signing, and dynamic pinning to the requests it processes:
+
+```swift
+import ApproovAsyncHTTPClient
+import AsyncHTTPClient
+import NIOPosix
+
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+let client = ApproovHTTPClient(eventLoopGroupProvider: .shared(group))
+
+// Perform a request — the Approov-Token header, substitutions, and pinning are applied automatically.
+let response = try client.get(url: "https://api.example.com/hello").wait()
+print(response.status)
+
+try client.syncShutdown()
+try group.syncShutdownGracefully()
+```
+
+For API domains that are configured to be protected with an Approov token, this adds the `Approov-Token` header and pins the connection. This may also substitute header values when using secrets protection. Unprotected and excluded domains are forwarded unchanged.
+
+### Error Messages
+The `ApproovService` functions may throw an `ApproovError` to provide additional information:
+
+* `permanentError`: Feature is not enabled or a configuration feature is unsupported.
+* `rejectionError`: Attestation has been rejected. The `ARC` and `rejectionReasons` may contain specific device information that would help troubleshooting.
+* `networkingError`: Generally can be retried since it is a temporary network issue.
+* `pinningError`: Certificate pinning validation error.
+* `configurationError`: Configuration feature is disabled or wrongly configured (e.g. attempting to initialize with a different configuration from a previous initialization).
+* `initializationFailure`: ApproovService failed to initialize.
+
+## CHECKING IT WORKS
+Initially you won't have set which API domains to protect, so the wrapper will not add anything. It will have called Approov though and made contact with the Approov cloud service. You will see logging from Approov saying `UNKNOWN_URL`.
+
+Your Approov onboarding email should contain a link allowing you to access [Live Metrics Graphs](https://approov.io/docs/latest/approov-usage-documentation/#metrics-graphs). After you've run your app with Approov integration you should be able to see the results in the live metrics within a minute or so. At this stage you could even release your app to get details of your app population and the attributes of the devices they are running upon.
+
+## NEXT STEPS
+To actually protect your APIs and/or secrets there are some further steps. Approov provides two different options for protection:
+
+* [API PROTECTION](https://github.com/approov/quickstart-ios-swift-asynchttpclient/blob/master/API-PROTECTION.md): You should use this if you control the backend API(s) being protected and are able to modify them to ensure that a valid Approov token is being passed by the app. An [Approov Token](https://approov.io/docs/latest/approov-usage-documentation/#approov-tokens) is a short-lived cryptographically signed JWT proving the authenticity of the call.
+
+* [SECRETS PROTECTION](https://github.com/approov/quickstart-ios-swift-asynchttpclient/blob/master/SECRETS-PROTECTION.md): This allows app secrets, including API keys for 3rd party services, to be protected so that they no longer need to be included in the released app code. These secrets are only made available to valid apps at runtime.
+
+Note that it is possible to use both approaches side-by-side in the same app.
+
+---
+
+## Useful Links
+
+- [Approov SDK](https://github.com/approov/approov-ios-sdk)
+- [AsyncHTTPClient Documentation](https://github.com/swift-server/async-http-client)
+- [Approov Website](https://www.approov.io)
+- [Quickstart Guide](https://github.com/approov/quickstart-ios-swift-asynchttpclient)
+- [Shapes App Example](https://github.com/approov/quickstart-ios-swift-asynchttpclient/blob/master/SHAPES-EXAMPLE.md)
+- [Changelog](CHANGELOG.md)
+- [Reference Documentation](REFERENCE.md)
+- [Usage Guide](USAGE.md)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,23 @@
 
 A wrapper for the [Approov SDK](https://github.com/approov/approov-ios-sdk) to enable easy integration when using [`AsyncHTTPClient`](https://github.com/swift-server/async-http-client) for making the API calls that you wish to protect with Approov. In order to use this you will need a trial or paid [Approov](https://www.approov.io) account.
 
-Please see the [Quickstart](https://github.com/approov/quickstart-ios-swift-asynchttpclient) for usage instructions.
+Please see the [Quickstart](https://github.com/approov/quickstart-ios-swift-asynchttpclient) for example integration.
+
+## Swift Package Manager Import
+
+When adding this package with Swift Package Manager, import the module as:
+
+```swift
+import ApproovAsyncHTTPClient
+import Approov
+```
+
+The primary client type is `ApproovHTTPClient`, while `ApproovService` provides lower-level configuration and direct SDK helper methods.
+
+# Reference
+
+Please see the [REFERENCE.md](REFERENCE.md) for more information on the Approov Service for AsyncHTTPClient.
+
+# Usage
+
+Please see the [USAGE.md](USAGE.md) for more information on how to use this wrapper.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -65,6 +65,8 @@ ApproovService.bindHeader = "Authorization"
 let header = ApproovService.bindHeader
 ```
 
+> **Important:** Automatic token binding (via `bindHeader`) and manual token binding (via `setDataHashInToken`) must **not** be mixed. Use one mechanism or the other. When `bindHeader` is set, the service layer reads that header from each outgoing request and supplies its hash to Approov, which will overwrite any value set manually with `setDataHashInToken`.
+
 ### approovTokenHeaderAndPrefix
 Sets the header that the Approov token is added on, as well as an optional prefix String (such as "Bearer "). By default the token is provided on "Approov-Token" with no prefix.
 
@@ -156,6 +158,8 @@ Updates a URL and `HTTPHeaders` collection with Approov protection and secure st
 ```swift
 let (updatedURL, updatedHeaders) = try ApproovService.updateRequest(url: url, headers: headers)
 ```
+
+> **Note:** This legacy convenience overload only carries a URL and headers — it assumes the `GET` method and no body. If you use a custom service mutator that performs message signing, prefer `signRequest(_:)` or the `ApproovHTTPClient` execute path so the actual method and body are available for the signature base.
 
 ### signRequest(_:)
 Convenience method that applies Approov protection to a `HTTPClient.Request` and returns the protected request directly. Note: This method is synchronous and may block briefly.
@@ -251,7 +255,7 @@ let deviceId = ApproovService.getDeviceID()
 ```
 
 ### setDataHashInToken(data:)
-Directly sets the data hash for subsequently fetched Approov tokens.
+Directly sets the data hash for subsequently fetched Approov tokens. This is the manual alternative to `bindHeader`; the two must not be mixed (see the note on `bindHeader`).
 
 ```swift
 ApproovService.setDataHashInToken(data: "<data-to-hash>")
@@ -303,7 +307,7 @@ let jwt = try ApproovService.fetchCustomJWT(payload: "{\"claims\":{}}")
 ```
 
 ### precheck()
-Performs a precheck to verify if the app will pass attestation.
+Performs a precheck to verify if the app will pass attestation. Internally this performs a secure string fetch with an `UNKNOWN_KEY`, which is treated as a success path. This is intended for **development-time** verification of an integration; it is not required in production flows. Throws `ApproovError` (e.g. `rejectionError` if the app fails attestation).
 
 ```swift
 try ApproovService.precheck()

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,75 +1,56 @@
 # Reference
 
-This provides a reference for the main public APIs exposed by the Approov Service for AsyncHTTPClient. These are available when you import the Swift Package Manager module:
+This provides a reference for the public methods and properties defined on `ApproovService` and the types exposed by the Approov Service for AsyncHTTPClient. These are available when you import the module:
 
 ```swift
 import ApproovAsyncHTTPClient
-import Approov
 ```
 
-## Main Types
-
-- `ApproovHTTPClient`: High-level AsyncHTTPClient wrapper that applies Approov protection to requests.
-- `ApproovService`: Static configuration and direct SDK helper API.
-- `ApproovPinningVerifier`: Pin verification helper used by the service layer for dynamic pinning.
-
-## Errors
-
-Most throwing methods raise `ApproovError`. The main cases are:
+Most methods either throw an `ApproovError` or return an `ApproovUpdateResponse`. The error cases to be aware of are:
 
 - `networkingError`: A temporary networking issue; offer a retry.
-- `rejectionError`: Attestation rejected; includes rejection details where available.
-- `permanentError` / `configurationError` / `initializationFailure` / `runtimeError`: Non-retryable in normal flows.
+- `rejectionError`: Attestation rejected; includes ARC and rejection reasons if enabled.
+- `permanentError` / `configurationError` / `initializationFailure`: Non-retryable in normal flows.
 
-## ApproovHTTPClient
-
-`ApproovHTTPClient` mirrors the upstream AsyncHTTPClient API while automatically protecting requests with Approov.
-
-### init(eventLoopGroupProvider:configuration:)
-Creates an `ApproovHTTPClient` using the supplied event loop group provider and optional AsyncHTTPClient configuration.
-
-```swift
-let client = ApproovHTTPClient(eventLoopGroupProvider: .shared(group))
-```
-
-### get / post / patch / put / delete
-Convenience methods for common HTTP verbs. These return `EventLoopFuture<HTTPClient.Response>`.
-
-```swift
-let response = try client.get(url: "https://api.example.com").wait()
-let response = try client.post(url: "https://api.example.com").wait()
-```
-
-### execute(...)
-`ApproovHTTPClient` also exposes the main `execute` overloads from AsyncHTTPClient for custom requests, including `HTTPClient.Request` and delegate-based execution. Use these when you need full request control.
-
-```swift
-let request = try HTTPClient.Request(url: "https://api.example.com", method: .GET)
-let response = try client.execute(request: request).wait()
-```
-
-### syncShutdown / shutdown
-Shuts down the wrapped AsyncHTTPClient.
-
-```swift
-try client.syncShutdown()
-client.shutdown { error in
-    print(error as Any)
-}
-```
+---
 
 ## ApproovService
 
-### initialize
-Initializes the SDK with the config obtained using `approov sdk -getConfigString` or in the original onboarding email. Repeated calls with the same config are ignored when `comment` is `nil`. If `comment` is non-`nil`, the call is passed through to the underlying SDK again. If the SDK has already been initialized by another service layer, the corresponding SDK error is logged and ignored.
+### initialize(config:comment:)
+Initializes the SDK with the config obtained using `approov sdk -getConfigString` or in the original onboarding email. In the vast majority of integrations, `initialize` should be called **once** during app startup. Each successful call resets all service-layer configuration (substitution headers, exclusion URL regexes, binding header, service mutator, `useApproovStatusIfNoToken`) to defaults.
+
+The native SDK (3.5+) accepts a same-config re-initialization by returning `false`/`NO` without error, which this service layer handles gracefully. However, calling `initialize` again with the same config still resets the service-layer state, so there is no benefit to doing so in normal app flows with a single service layer.
 
 ```swift
 try ApproovService.initialize(config: "<config-string>")
-try ApproovService.initialize(config: "<config-string>", comment: "reinit:example-option")
+```
+
+An optional `comment` parameter is forwarded directly to the native SDK. The `comment` should be `nil` unless you are using SDK initialization options or performing an explicit SDK reinitialization (e.g. `"options:no-install-key"` or `"reinit"`).
+
+```swift
+try ApproovService.initialize(config: "<config-string>", comment: "options:no-install-key")
+```
+
+If an attempt is made to initialize with a **different** non-empty config, an `ApproovError.initializationFailure` is raised.
+
+Passing an empty config string bypasses Approov SDK initialization. In that mode, the service layer still reports itself as initialized, but requests are forwarded as plain `HTTPClient` traffic without Approov token injection, message signing, secure strings, or pinning. A later call to `initialize()` with a valid non-empty config string will then enable the native Approov SDK at runtime.
+
+### isInitialized()
+Returns whether the service layer has been initialized.
+
+```swift
+let initialized = ApproovService.isInitialized()
+```
+
+### isApproovEnabled()
+Returns whether Approov protection is currently enabled (initialized with a valid, non-empty configuration string).
+
+```swift
+let enabled = ApproovService.isApproovEnabled()
 ```
 
 ### proceedOnNetworkFail
-Controls whether requests should proceed when Approov cannot fetch due to temporary network failures.
+*DEPRECATED* Use `setServiceMutator` instead to customize network failure behavior. Controls whether network calls should proceed when Approov cannot fetch due to network errors.
 
 ```swift
 ApproovService.proceedOnNetworkFail = true
@@ -77,7 +58,7 @@ let proceed = ApproovService.proceedOnNetworkFail
 ```
 
 ### bindHeader
-Sets the header whose value is hashed into the Approov token for token binding.
+Sets a binding header that must be present on all requests using the Approov service. A hash of the header value is supplied to Approov so the issued token is bound to the value.
 
 ```swift
 ApproovService.bindHeader = "Authorization"
@@ -85,7 +66,7 @@ let header = ApproovService.bindHeader
 ```
 
 ### approovTokenHeaderAndPrefix
-Sets the header name used for the Approov token and an optional prefix.
+Sets the header that the Approov token is added on, as well as an optional prefix String (such as "Bearer "). By default the token is provided on "Approov-Token" with no prefix.
 
 ```swift
 ApproovService.approovTokenHeaderAndPrefix = (
@@ -94,138 +75,279 @@ ApproovService.approovTokenHeaderAndPrefix = (
 )
 ```
 
-### setDevKey
-Sets a development key used for development and testing flows.
+### getApproovTokenHeader()
+Returns the name of the header used to carry the Approov token.
+
+```swift
+let header = ApproovService.getApproovTokenHeader()
+```
+
+### setApproovTraceIDHeader(header:)
+Sets the header name used to carry the optional Approov TraceID. Pass `nil` to disable.
+
+```swift
+ApproovService.setApproovTraceIDHeader(header: "Approov-TraceID")
+ApproovService.setApproovTraceIDHeader(header: nil)
+```
+
+### getApproovTraceIDHeader()
+Returns the configured TraceID header name, or `nil` if disabled.
+
+```swift
+let header = ApproovService.getApproovTraceIDHeader()
+```
+
+### setUseApproovStatusIfNoToken(shouldUse:)
+Sets a flag indicating if the Approov fetch status (e.g. `NO_NETWORK`, `MITM_DETECTED`) should be used as the token header value if the actual token fetch fails or returns an empty token.
+
+```swift
+ApproovService.setUseApproovStatusIfNoToken(shouldUse: true)
+```
+
+### getUseApproovStatusIfNoToken()
+Returns the current setting for using the Approov status if no token is available.
+
+```swift
+let shouldUse = ApproovService.getUseApproovStatusIfNoToken()
+```
+
+### setLoggingLevel(_:)
+Sets the service-layer logging level. This controls the verbosity of unified logging (`os_log`) output generated internally by the package.
+
+Available levels: `.off`, `.error`, `.warning`, `.info`, `.debug`.
+
+```swift
+ApproovService.loggingLevel = .debug
+let level = ApproovService.loggingLevel
+```
+
+### setServiceMutator(_:)
+Installs a service mutator to customize behavior at key points in the service flow. Pass `nil` to restore defaults.
+
+```swift
+ApproovService.setServiceMutator(myMutator)
+ApproovService.setServiceMutator(nil)
+```
+
+### getServiceMutator()
+Returns the currently active service mutator.
+
+```swift
+let mutator = ApproovService.getServiceMutator()
+```
+
+### setDevKey(devKey:)
+Sets a development key indicating that the app is a development version.
 
 ```swift
 ApproovService.setDevKey(devKey: "<dev-key>")
 ```
 
-### prefetch
-Starts an early background token fetch after initialization.
+### prefetch()
+*OBSOLETE* This method is obsolete and is now a no-op. The underlying Approov SDK manages prefetching automatically.
 
 ```swift
 ApproovService.prefetch()
 ```
 
-### updateRequest
-Updates a URL and `HTTPHeaders` collection with Approov protection and secure string substitutions.
+### updateRequest(url:headers:)
+Updates a URL and `HTTPHeaders` collection with Approov protection and secure string substitutions. This is a synchronous blocking method.
 
 ```swift
 let (updatedURL, updatedHeaders) = try ApproovService.updateRequest(url: url, headers: headers)
 ```
 
-### addSubstitutionHeader
-Adds a header that should have its value treated as a secure string lookup key.
+### signRequest(_:)
+Convenience method that applies Approov protection to a `HTTPClient.Request` and returns the protected request directly. Note: This method is synchronous and may block briefly.
+
+```swift
+let protectedRequest = try ApproovService.signRequest(originalRequest)
+```
+
+> **Important — Dynamic Pinning:** `signRequest` does **not** apply dynamic TLS pinning. When you use `ApproovHTTPClient`, the client automatically validates TLS certificates using the `ApproovPinningVerifier`. A plain `HTTPClient` bypasses this. If you use `signRequest` with your own client, you are responsible for certificate pinning verification separately.
+
+### setFailureCacheTTL(ttl:)
+Sets the time-to-live (TTL) in seconds for thread-safe failure mode caching.
+
+```swift
+ApproovService.setFailureCacheTTL(ttl: 5.0)
+```
+
+### updateRequestWithApproov(request:)
+Updates an `ApproovRequest` with Approov protection (token, substitutions, etc.) and returns an `ApproovUpdateResponse` describing the decision and any error.
+
+```swift
+let response = ApproovService.updateRequestWithApproov(request: request)
+```
+
+### addSubstitutionHeader(header:prefix:)
+Adds a header name to be subject to secure string substitution.
 
 ```swift
 ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: nil)
-ApproovService.addSubstitutionHeader(header: "Authorization", prefix: "Bearer ")
 ```
 
-### removeSubstitutionHeader
-Removes a header previously configured for secure string substitution.
+### removeSubstitutionHeader(header:)
+Removes a header previously added for substitution.
 
 ```swift
 ApproovService.removeSubstitutionHeader(header: "Api-Key")
 ```
 
-### substituteQueryParam
-Substitutes a single query parameter value in a URL using a secure string lookup.
+### getSubstitutionHeaders()
+Returns the dictionary of headers currently subject to secure string substitution.
 
 ```swift
-let updatedURL = try ApproovService.substituteQueryParam(url: url, queryParameter: "api_key")
+let headers = ApproovService.getSubstitutionHeaders()
 ```
 
-### addSubstitutionQueryParam
-Adds a query parameter key for secure string substitution.
+### addSubstitutionQueryParam(key:)
+Adds a query parameter key name to be subject to secure string substitution.
 
 ```swift
 ApproovService.addSubstitutionQueryParam(key: "api_key")
 ```
 
-### removeSubstitutionQueryParam
-Removes a query parameter key previously added for substitution.
+### removeSubstitutionQueryParam(key:)
+Removes a query parameter key name previously added.
 
 ```swift
 ApproovService.removeSubstitutionQueryParam(key: "api_key")
 ```
 
-### addExclusionURLRegex
+### getSubstitutionQueryParams()
+Returns the set of query parameter keys subject to secure string substitution.
+
+```swift
+let params = ApproovService.getSubstitutionQueryParams()
+```
+
+### addExclusionURLRegex(urlRegex:)
 Adds an exclusion URL regular expression. Matching URLs bypass all Approov processing.
 
 ```swift
-ApproovService.addExclusionURLRegex(urlRegex: "^https://example\.com/public/.*$")
+ApproovService.addExclusionURLRegex(urlRegex: "^https://example\\.com/unprotected/.*$")
 ```
 
-### removeExclusionURLRegex
+### removeExclusionURLRegex(urlRegex:)
 Removes a previously added exclusion URL regular expression.
 
 ```swift
-ApproovService.removeExclusionURLRegex(urlRegex: "^https://example\.com/public/.*$")
+ApproovService.removeExclusionURLRegex(urlRegex: "^https://example\\.com/unprotected/.*$")
 ```
 
-### getDeviceID
-Returns the device ID used by Approov for this app installation.
+### getExclusionURLRegexs()
+Returns the current dictionary of exclusion URL regexes.
 
 ```swift
-let deviceId = try ApproovService.getDeviceID()
+let regexs = ApproovService.getExclusionURLRegexs()
 ```
 
-### setDataHashInToken
-Directly sets the data hash to be included in subsequently fetched Approov tokens.
+### getDeviceID()
+Gets the device ID used by Approov.
+
+```swift
+let deviceId = ApproovService.getDeviceID()
+```
+
+### setDataHashInToken(data:)
+Directly sets the data hash for subsequently fetched Approov tokens.
 
 ```swift
 ApproovService.setDataHashInToken(data: "<data-to-hash>")
 ```
 
-### fetchToken
-Fetches an Approov token for the supplied URL.
+### fetchToken(url:)
+Performs a token fetch for the given URL. Throws `ApproovError` if the fetch fails.
 
 ```swift
-let token = try ApproovService.fetchToken(url: "https://api.example.com")
+let token = try ApproovService.fetchToken(url: "https://example.com/api")
 ```
 
-### getMessageSignature
-Returns an account message signature if the feature is enabled and key material is available.
+### setInstallAttrsInToken(attrs:)
+Sets installation-specific attributes in the token.
 
 ```swift
-let signature = try ApproovService.getMessageSignature(message: "example-message")
+try ApproovService.setInstallAttrsInToken(attrs: "my-attributes")
 ```
 
-### fetchSecureString
-Fetches or defines a secure string.
+### getAccountMessageSignature(message:)
+Gets the signature for the given message using the account-specific HMAC-SHA256 signing key.
+
+```swift
+let signature = ApproovService.getAccountMessageSignature(message: "message")
+```
+
+### getInstallMessageSignature(message:)
+Gets the signature for the given message using the install-specific signing key.
+
+```swift
+let signature = ApproovService.getInstallMessageSignature(message: "message")
+```
+
+### getMessageSignature(message:)
+*OBSOLETE* Use `getAccountMessageSignature` or `getInstallMessageSignature` instead.
+
+### fetchSecureString(key:newDef:)
+Fetches a secure string with the given key.
 
 ```swift
 let value = try ApproovService.fetchSecureString(key: "api_key", newDef: nil)
-let defined = try ApproovService.fetchSecureString(key: "tenant-key", newDef: "secret-value")
 ```
 
-### fetchCustomJWT
-Fetches a custom JWT with the supplied JSON payload.
+### fetchCustomJWT(payload:)
+Fetches a custom JWT with the given payload.
 
 ```swift
 let jwt = try ApproovService.fetchCustomJWT(payload: "{\"claims\":{}}")
 ```
 
-### precheck
-Performs a precheck to determine if the app will pass attestation.
+### precheck()
+Performs a precheck to verify if the app will pass attestation.
 
 ```swift
 try ApproovService.precheck()
 ```
 
-### getLastARC
-Returns the last Attestation Response Code when available.
+### getLastARC()
+Gets the last Attestation Response Code.
 
 ```swift
 let arc = ApproovService.getLastARC()
 ```
 
+---
+
+## ApproovHTTPClient
+
+An `ApproovHTTPClient` manages the underlying `HTTPClient` and automatically injects Approov tokens, processes secure string substitutions, and validates connections using `ApproovPinningVerifier`.
+
+### init(eventLoopGroupProvider:configuration:)
+Creates an instance of `ApproovHTTPClient`.
+
+```swift
+let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
+```
+
+### get / post / patch / put / delete
+Convenience HTTP verbs returning `EventLoopFuture<HTTPClient.Response>`.
+
+### execute(...)
+Executes a request using custom `HTTPClient.Request` objects or custom delegates.
+
+### shutdown(queue:_:) / syncShutdown()
+Initiates shutdown of the client.
+
+```swift
+try client.syncShutdown()
+```
+
+---
+
 ## ApproovPinningVerifier
 
 ### verifyPinning(sec_protocol_metadata:)
-Advanced pinning integration point for use with custom TLS handling.
+Static helper used internally by the client's TLS configuration. Returns a boolean indicating if pinning check passed.
 
 ```swift
 let isPinned = ApproovPinningVerifier.verifyPinning(sec_protocol_metadata: metadata)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,0 +1,232 @@
+# Reference
+
+This provides a reference for the main public APIs exposed by the Approov Service for AsyncHTTPClient. These are available when you import the Swift Package Manager module:
+
+```swift
+import ApproovAsyncHTTPClient
+import Approov
+```
+
+## Main Types
+
+- `ApproovHTTPClient`: High-level AsyncHTTPClient wrapper that applies Approov protection to requests.
+- `ApproovService`: Static configuration and direct SDK helper API.
+- `ApproovPinningVerifier`: Pin verification helper used by the service layer for dynamic pinning.
+
+## Errors
+
+Most throwing methods raise `ApproovError`. The main cases are:
+
+- `networkingError`: A temporary networking issue; offer a retry.
+- `rejectionError`: Attestation rejected; includes rejection details where available.
+- `permanentError` / `configurationError` / `initializationFailure` / `runtimeError`: Non-retryable in normal flows.
+
+## ApproovHTTPClient
+
+`ApproovHTTPClient` mirrors the upstream AsyncHTTPClient API while automatically protecting requests with Approov.
+
+### init(eventLoopGroupProvider:configuration:)
+Creates an `ApproovHTTPClient` using the supplied event loop group provider and optional AsyncHTTPClient configuration.
+
+```swift
+let client = ApproovHTTPClient(eventLoopGroupProvider: .shared(group))
+```
+
+### get / post / patch / put / delete
+Convenience methods for common HTTP verbs. These return `EventLoopFuture<HTTPClient.Response>`.
+
+```swift
+let response = try client.get(url: "https://api.example.com").wait()
+let response = try client.post(url: "https://api.example.com").wait()
+```
+
+### execute(...)
+`ApproovHTTPClient` also exposes the main `execute` overloads from AsyncHTTPClient for custom requests, including `HTTPClient.Request` and delegate-based execution. Use these when you need full request control.
+
+```swift
+let request = try HTTPClient.Request(url: "https://api.example.com", method: .GET)
+let response = try client.execute(request: request).wait()
+```
+
+### syncShutdown / shutdown
+Shuts down the wrapped AsyncHTTPClient.
+
+```swift
+try client.syncShutdown()
+client.shutdown { error in
+    print(error as Any)
+}
+```
+
+## ApproovService
+
+### initialize
+Initializes the SDK with the config obtained using `approov sdk -getConfigString` or in the original onboarding email. Repeated calls with the same config are ignored when `comment` is `nil`. If `comment` is non-`nil`, the call is passed through to the underlying SDK again. If the SDK has already been initialized by another service layer, the corresponding SDK error is logged and ignored.
+
+```swift
+try ApproovService.initialize(config: "<config-string>")
+try ApproovService.initialize(config: "<config-string>", comment: "reinit:example-option")
+```
+
+### proceedOnNetworkFail
+Controls whether requests should proceed when Approov cannot fetch due to temporary network failures.
+
+```swift
+ApproovService.proceedOnNetworkFail = true
+let proceed = ApproovService.proceedOnNetworkFail
+```
+
+### bindHeader
+Sets the header whose value is hashed into the Approov token for token binding.
+
+```swift
+ApproovService.bindHeader = "Authorization"
+let header = ApproovService.bindHeader
+```
+
+### approovTokenHeaderAndPrefix
+Sets the header name used for the Approov token and an optional prefix.
+
+```swift
+ApproovService.approovTokenHeaderAndPrefix = (
+    approovTokenHeader: "Approov-Token",
+    approovTokenPrefix: ""
+)
+```
+
+### setDevKey
+Sets a development key used for development and testing flows.
+
+```swift
+ApproovService.setDevKey(devKey: "<dev-key>")
+```
+
+### prefetch
+Starts an early background token fetch after initialization.
+
+```swift
+ApproovService.prefetch()
+```
+
+### updateRequest
+Updates a URL and `HTTPHeaders` collection with Approov protection and secure string substitutions.
+
+```swift
+let (updatedURL, updatedHeaders) = try ApproovService.updateRequest(url: url, headers: headers)
+```
+
+### addSubstitutionHeader
+Adds a header that should have its value treated as a secure string lookup key.
+
+```swift
+ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: nil)
+ApproovService.addSubstitutionHeader(header: "Authorization", prefix: "Bearer ")
+```
+
+### removeSubstitutionHeader
+Removes a header previously configured for secure string substitution.
+
+```swift
+ApproovService.removeSubstitutionHeader(header: "Api-Key")
+```
+
+### substituteQueryParam
+Substitutes a single query parameter value in a URL using a secure string lookup.
+
+```swift
+let updatedURL = try ApproovService.substituteQueryParam(url: url, queryParameter: "api_key")
+```
+
+### addSubstitutionQueryParam
+Adds a query parameter key for secure string substitution.
+
+```swift
+ApproovService.addSubstitutionQueryParam(key: "api_key")
+```
+
+### removeSubstitutionQueryParam
+Removes a query parameter key previously added for substitution.
+
+```swift
+ApproovService.removeSubstitutionQueryParam(key: "api_key")
+```
+
+### addExclusionURLRegex
+Adds an exclusion URL regular expression. Matching URLs bypass all Approov processing.
+
+```swift
+ApproovService.addExclusionURLRegex(urlRegex: "^https://example\.com/public/.*$")
+```
+
+### removeExclusionURLRegex
+Removes a previously added exclusion URL regular expression.
+
+```swift
+ApproovService.removeExclusionURLRegex(urlRegex: "^https://example\.com/public/.*$")
+```
+
+### getDeviceID
+Returns the device ID used by Approov for this app installation.
+
+```swift
+let deviceId = try ApproovService.getDeviceID()
+```
+
+### setDataHashInToken
+Directly sets the data hash to be included in subsequently fetched Approov tokens.
+
+```swift
+ApproovService.setDataHashInToken(data: "<data-to-hash>")
+```
+
+### fetchToken
+Fetches an Approov token for the supplied URL.
+
+```swift
+let token = try ApproovService.fetchToken(url: "https://api.example.com")
+```
+
+### getMessageSignature
+Returns an account message signature if the feature is enabled and key material is available.
+
+```swift
+let signature = try ApproovService.getMessageSignature(message: "example-message")
+```
+
+### fetchSecureString
+Fetches or defines a secure string.
+
+```swift
+let value = try ApproovService.fetchSecureString(key: "api_key", newDef: nil)
+let defined = try ApproovService.fetchSecureString(key: "tenant-key", newDef: "secret-value")
+```
+
+### fetchCustomJWT
+Fetches a custom JWT with the supplied JSON payload.
+
+```swift
+let jwt = try ApproovService.fetchCustomJWT(payload: "{\"claims\":{}}")
+```
+
+### precheck
+Performs a precheck to determine if the app will pass attestation.
+
+```swift
+try ApproovService.precheck()
+```
+
+### getLastARC
+Returns the last Attestation Response Code when available.
+
+```swift
+let arc = ApproovService.getLastARC()
+```
+
+## ApproovPinningVerifier
+
+### verifyPinning(sec_protocol_metadata:)
+Advanced pinning integration point for use with custom TLS handling.
+
+```swift
+let isPinned = ApproovPinningVerifier.verifyPinning(sec_protocol_metadata: metadata)
+```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -352,3 +352,11 @@ Static helper used internally by the client's TLS configuration. Returns a boole
 ```swift
 let isPinned = ApproovPinningVerifier.verifyPinning(sec_protocol_metadata: metadata)
 ```
+
+### Dynamic Pinning Behavior
+
+Approov pins are evaluated by the verifier **once per TLS handshake**. On each new connection the verifier calls `Approov.getPins("public-key-sha256")` to obtain the current pin set, so any dynamic pin update delivered by the Approov SDK takes effect immediately for **every connection established after the update**. If the presented certificate chain does not match the current pins, the handshake fails and that connection is never used.
+
+Pins are matched against the certificate chain that the operating system actually validated (the path built to a trusted anchor), not the raw chain presented by the server. Extra certificates a peer includes that are not part of the validated path cannot satisfy a pin.
+
+> **Note — pooled connections and pin updates:** `ApproovHTTPClient` reuses the connection pool managed by the underlying `HTTPClient`. Because pinning is enforced at handshake time, a connection that was already open and validated under a previous pin set continues to serve requests until it is closed and re-established (for example when it idles out of the pool or the server closes it). New pins are therefore guaranteed to be enforced on all *new* connections immediately, but an existing pooled connection may continue to be used briefly after a pin update. Applications that require all in-flight connections to re-pin immediately after a dynamic update should create a fresh `ApproovHTTPClient` (and shut down the previous one), which forces every subsequent connection to re-handshake under the current pins.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+We maintain updates and patches for the latest release. Earlier versions will still work, but will have less functionality than later versions.
+We encourage all users of these service layers to update to the latest version for the best experience.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.5.x   | :white_check_mark: |
+| < 3.5   | :x:                |
+
+## Reporting a Vulnerability
+
+Thank you for letting us know about possible security vulnerabilities in this project.
+Please don't publish details in a public issue or PR. Send us a private email at support@approov.io and please disclose which version your report refers to.
+
+Your message will receive a prompt reply.

--- a/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
@@ -1,0 +1,549 @@
+// MIT License
+//
+// Copyright (c) 2016-present, Approov Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+// (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+// ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import CommonCrypto
+import Foundation
+import os.log
+import RawStructuredFieldValues
+import NIOHTTP1
+
+/**
+ * Provides a base implementation of message signing for Approov when using
+ * AsyncHTTPClient requests. This class provides mechanisms to configure and apply
+ * message signatures to HTTP requests based on specified parameters and
+ * algorithms.
+ */
+public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringConvertible {
+
+    /**
+     * Constant for the SHA-256 digest algorithm (used for body digests).
+     */
+    public static let DIGEST_SHA256 = "sha-256"
+
+    /**
+     * Constant for the SHA-512 digest algorithm (used for body digests).
+     */
+    public static let DIGEST_SHA512 = "sha-512"
+
+    /**
+     * Constant for the ECDSA P-256 with SHA-256 algorithm (used when signing with install private key).
+     */
+    public static let ALG_ES256 = "ecdsa-p256-sha256"
+
+    /**
+     * Constant for the HMAC with SHA-256 algorithm (used when signing with the account signing key).
+     */
+    public static let ALG_HS256 = "hmac-sha256"
+
+    /**
+     * Default factory for generating signature parameters.
+     */
+    private var defaultFactory: SignatureParametersFactory?
+
+    /**
+     * Host-specific factories for generating signature parameters.
+     */
+    private var hostFactories: [String: SignatureParametersFactory]
+
+    /**
+     * Initializer
+     */
+    public init() {
+        hostFactories = [:]
+    }
+
+    public var description: String {
+        return "ApproovDefaultMessageSigning"
+    }
+
+    /**
+     * Sets the default factory for generating signature parameters.
+     *
+     * - Parameter factory: The factory to set as the default.
+     * - Returns: The current instance for method chaining.
+     */
+    public func setDefaultFactory(_ factory: SignatureParametersFactory) -> ApproovDefaultMessageSigning {
+        defaultFactory = factory
+        return self
+    }
+
+    /**
+     * Associates a specific host with a factory for generating signature parameters.
+     *
+     * - Parameters:
+     *   - hostName: The host name.
+     *   - factory: The factory to associate with the host.
+     * - Returns: The current instance for method chaining.
+     */
+    public func putHostFactory(hostName: String, factory: SignatureParametersFactory) -> ApproovDefaultMessageSigning {
+        hostFactories[hostName] = factory
+        return self
+    }
+
+    /**
+     * Builds the signature parameters for a given request.
+     *
+     * - Parameters:
+     *   - provider: The component provider for the request.
+     *   - changes: The request mutations to apply.
+     * - Returns: The generated `SignatureParameters`, or `nil` if no factory is available.
+     */
+    private func buildSignatureParameters(provider: ApproovAsyncHTTPClientComponentProvider, changes: ApproovRequestMutations) throws -> SignatureParameters? {
+        let factory = hostFactories[provider.getAuthority()] ?? defaultFactory
+        return try factory?.buildSignatureParameters(provider: provider, changes: changes)
+    }
+
+    /**
+     * Processes a request to add message signature headers.
+     *
+     * - Parameters:
+     *   - request: The original HTTP request.
+     *   - changes: The request mutations that were applied by the Approov interceptor.
+     * - Returns: The processed HTTP request with the signature headers added.
+     * - Throws: An `ApproovError` if an error occurs during processing.
+     */
+    public func handleInterceptorProcessedRequest(_ request: ApproovRequest,
+                                                   changes: ApproovRequestMutations) throws -> ApproovRequest {
+        return try processedRequest(request, changes: changes)
+    }
+
+    /**
+     * Helper to process the request signature changes.
+     */
+    public func processedRequest(_ request: ApproovRequest, changes: ApproovRequestMutations) throws -> ApproovRequest {
+        // If the request doesn't have an Approov token, we don't need to sign it
+        if request.headers.first(name: ApproovService.getApproovTokenHeader()) != nil {
+            // Generate and add a message signature
+            let provider = ApproovAsyncHTTPClientComponentProvider(request: request)
+            guard let params = try buildSignatureParameters(provider: provider, changes: changes) else {
+                // No signature to be added; proceed with the original request
+                return request
+            }
+
+            // Build the signature base
+            let baseBuilder = SignatureBaseBuilder(sigParams: params, ctx: provider)
+            let message = try baseBuilder.createSignatureBase()
+            // WARNING never log the message as it contains an Approov token which provides access to your API.
+
+            // Generate the signature
+            let sigId: String
+            let signature: Data
+            switch params.getAlg() {
+            case ApproovDefaultMessageSigning.ALG_ES256:
+                sigId = "install"
+                guard let base64Signature = ApproovService.getInstallMessageSignature(message: message),
+                      let decodedSignature = Data(base64Encoded: base64Signature) else {
+                    if ApproovService.loggingLevel >= .error {
+                        os_log("ApproovService: install message signature unavailable, skipping signing", type: .error)
+                    }
+                    return provider.getRequest()
+                }
+                // decode the signature from ASN.1 DER format
+                signature = try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(decodedSignature)
+            case ApproovDefaultMessageSigning.ALG_HS256:
+                sigId = "account"
+                guard let base64Signature = ApproovService.getAccountMessageSignature(message: message),
+                      let decodedSignature = Data(base64Encoded: base64Signature) else {
+                    if ApproovService.loggingLevel >= .error {
+                        os_log("ApproovService: account message signature unavailable, skipping signing", type: .error)
+                    }
+                    return provider.getRequest()
+                }
+                signature = decodedSignature
+            default:
+                throw ApproovError.permanentError(message: "Unsupported algorithm identifier: \(params.getAlg() ?? "unknown")")
+            }
+
+            // Create signature headers
+            guard let sigHeader = try SFV.serializeDictionary(key: sigId, data: signature) else {
+                throw ApproovError.permanentError(message: "Failed to serialize signature header")
+            }
+            guard let sigInputHeader = try SFV.serializeDictionary(key: sigId, innerList: params.toComponentValue()) else {
+                throw ApproovError.permanentError(message: "Failed to serialize signature input header")
+            }
+
+            // Add headers to the request
+            var signedRequest = provider.getRequest()
+            signedRequest.headers.add(name: "Signature", value: sigHeader)
+            signedRequest.headers.add(name: "Signature-Input", value: sigInputHeader)
+
+            if params.isDebugMode() {
+                let digest = ApproovDefaultMessageSigning.sha256(data: Data(message.utf8))
+                if let sigBaseDigestHeader = try SFV.serializeDictionary(key: "sha-256", data: digest) {
+                    signedRequest.headers.add(name: "Signature-Base-Digest", value: sigBaseDigestHeader)
+                } else {
+                    if ApproovService.loggingLevel >= .debug {
+                        os_log("ApproovService: Failed to get digest algorithm - no debug entry", type: .debug)
+                    }
+                }
+            }
+
+            return signedRequest
+        }
+
+        return request
+    }
+
+    /**
+     * SHA256 of given input bytes.
+     *
+     * @param data is the input data
+     * @return the hash data
+     */
+    static func sha256(data: Data) -> Data {
+        var hash = [UInt8](repeating: 0,  count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
+        }
+        return Data(hash)
+    }
+
+    // Decode ASN.1 DER encoded ES256 signature into "raw" signature format
+    private static func decodeASN_1_DER_ES256_Signature(_ signature: Data) throws -> Data {
+        var offset = 0
+
+        // Ensure the signature starts with a valid ASN.1 sequence
+        guard signature[offset] == 0x30 else {
+            throw ApproovError.permanentError(message: "Invalid ASN.1 DER sequence")
+        }
+        offset += 1
+
+        // Read the total length of the sequence
+        let sequenceLength = Int(signature[offset])
+        offset += 1
+
+        guard sequenceLength == signature.count - 2 else {
+            throw ApproovError.permanentError(message: "Invalid ASN.1 DER sequence length")
+        }
+
+        // Decode the first integer (r)
+        guard signature[offset] == 0x02 else {
+            throw ApproovError.permanentError(message: "Invalid ASN.1 DER integer for r")
+        }
+        offset += 1
+
+        let rLength = Int(signature[offset])
+        offset += 1
+
+        let rBytes = signature[offset..<(offset + rLength)]
+        offset += rLength
+
+        // Decode the second integer (s)
+        guard signature[offset] == 0x02 else {
+            throw ApproovError.permanentError(message: "Invalid ASN.1 DER integer for s")
+        }
+        offset += 1
+
+        let sLength = Int(signature[offset])
+        offset += 1
+
+        let sBytes = signature[offset..<(offset + sLength)]
+        offset += sLength
+
+        // Ensure the entire signature has been processed
+        guard offset == signature.count else {
+            throw ApproovError.permanentError(message: "Extra data in ASN.1 DER signature")
+        }
+
+        return try to32ByteData(bytes: rBytes) + to32ByteData(bytes: sBytes)
+    }
+
+    private static func to32ByteData(bytes: Data) throws -> Data {
+        if bytes.count < 32 {
+            let padding = Data(repeating: 0, count: 32 - bytes.count)
+            return padding + bytes
+        } else if bytes.count == 32 {
+            // Return as-is if the byte array is exactly 32 bytes
+            return bytes
+        } else if bytes.count == 33 && bytes.first == 0 {
+            // Remove the leading zero if the byte array is 33 bytes and starts with 0
+            return bytes.dropFirst()
+        } else {
+            // Throw an error if the byte array cannot be represented as 32 bytes
+            throw ApproovError.permanentError(message: "Not an ASN.1 DER ES256 signature part")
+        }
+    }
+
+    /**
+     * Generates a default `SignatureParametersFactory` with predefined settings and optional base parameters.
+     *
+     * - Parameter baseParametersOverride: The base parameters to override, or `nil` to use defaults.
+     * - Returns: A new instance of `SignatureParametersFactory`.
+     */
+    public static func generateDefaultSignatureParametersFactory(baseParametersOverride: SignatureParameters? = nil) -> SignatureParametersFactory {
+        let defaultExpiresLifetime: Int64 = 15
+        let baseParameters: SignatureParameters
+
+        if let override = baseParametersOverride {
+            baseParameters = override
+        } else {
+            baseParameters = SignatureParameters()
+                .addComponentIdentifier(ApproovAsyncHTTPClientComponentProvider.DC_METHOD)
+                .addComponentIdentifier(ApproovAsyncHTTPClientComponentProvider.DC_TARGET_URI)
+        }
+
+        let defaultSignatureParametersFactory = SignatureParametersFactory()
+            .setBaseParameters(baseParameters)
+            .setUseInstallMessageSigning()
+            .setAddCreated(true)
+            .setExpiresLifetime(defaultExpiresLifetime)
+            .setAddApproovTokenHeader(true)
+            .setAddApproovTraceIDHeader(true)
+            .addOptionalHeaders(["Authorization", "Content-Length", "Content-Type"])
+        do {
+            try defaultSignatureParametersFactory.setBodyDigestConfig(ApproovDefaultMessageSigning.DIGEST_SHA256, required: false)
+        } catch {
+            if ApproovService.loggingLevel >= .error {
+                os_log("ApproovDefaultMessageSigning - generateDefaultSignatureParametersFactory: Failed to set default body digest algorithm", type: .error)
+            }
+        }
+        return defaultSignatureParametersFactory
+    }
+}
+
+/**
+ * Factory class for creating pre-request `SignatureParameters` with configurable settings.
+ */
+public class SignatureParametersFactory {
+    private var baseParameters: SignatureParameters?
+    private var bodyDigestAlgorithm: String?
+    private var bodyDigestRequired: Bool = false
+    private var useAccountMessageSigning: Bool = false
+    private var addCreated: Bool = false
+    private var expiresLifetime: Int64 = 0
+    private var addApproovTokenHeader: Bool = false
+    private var addApproovTraceIDHeader: Bool = false
+    private var optionalHeaders: [String] = []
+
+    public func setBaseParameters(_ baseParameters: SignatureParameters) -> SignatureParametersFactory {
+        self.baseParameters = baseParameters
+        return self
+    }
+
+    public func setBodyDigestConfig(_ bodyDigestAlgorithm: String?, required: Bool) throws -> SignatureParametersFactory {
+        if let algorithm = bodyDigestAlgorithm {
+            guard algorithm == ApproovDefaultMessageSigning.DIGEST_SHA256 ||
+                  algorithm == ApproovDefaultMessageSigning.DIGEST_SHA512 else {
+                throw ApproovError.permanentError(message: "Unsupported body digest algorithm: \(algorithm)")
+            }
+            self.bodyDigestAlgorithm = algorithm
+            self.bodyDigestRequired = required
+        } else {
+            self.bodyDigestRequired = false
+        }
+        return self
+    }
+
+    public func setUseInstallMessageSigning() -> SignatureParametersFactory {
+        self.useAccountMessageSigning = false
+        return self
+    }
+
+    public func setUseAccountMessageSigning() -> SignatureParametersFactory {
+        self.useAccountMessageSigning = true
+        return self
+    }
+
+    public func setAddCreated(_ addCreated: Bool) -> SignatureParametersFactory {
+        self.addCreated = addCreated
+        return self
+    }
+
+    public func setExpiresLifetime(_ expiresLifetime: Int64) -> SignatureParametersFactory {
+        self.expiresLifetime = expiresLifetime
+        return self
+    }
+
+    public func setAddApproovTokenHeader(_ addApproovTokenHeader: Bool) -> SignatureParametersFactory {
+        self.addApproovTokenHeader = addApproovTokenHeader
+        return self
+    }
+
+    public func setAddApproovTraceIDHeader(_ addApproovTraceIDHeader: Bool) -> SignatureParametersFactory {
+        self.addApproovTraceIDHeader = addApproovTraceIDHeader
+        return self
+    }
+
+    public func addOptionalHeaders(_ headers: [String]) -> SignatureParametersFactory {
+        self.optionalHeaders.append(contentsOf: headers)
+        return self
+    }
+
+    func buildSignatureParameters(provider: ApproovAsyncHTTPClientComponentProvider, changes: ApproovRequestMutations) throws -> SignatureParameters {
+        var requestParameters: SignatureParameters
+        if baseParameters == nil {
+            requestParameters = SignatureParameters()
+        } else {
+            requestParameters = SignatureParameters(base: baseParameters!)
+        }
+        requestParameters.setAlg(useAccountMessageSigning ? ApproovDefaultMessageSigning.ALG_HS256 : ApproovDefaultMessageSigning.ALG_ES256)
+
+        if addCreated || expiresLifetime > 0 {
+            let currentTime = Int64(Date().timeIntervalSince1970)
+            if addCreated {
+                requestParameters.setCreated(currentTime)
+            }
+            if expiresLifetime > 0 {
+                requestParameters.setExpires(currentTime + expiresLifetime)
+            }
+        }
+
+        if addApproovTokenHeader, let tokenHeaderKey = changes.getTokenHeaderKey() {
+            requestParameters.addComponentIdentifier(tokenHeaderKey)
+        }
+
+        if addApproovTraceIDHeader, let traceIDHeaderKey = changes.getTraceIDHeaderKey() {
+            requestParameters.addComponentIdentifier(traceIDHeaderKey)
+        }
+
+        for headerName in optionalHeaders {
+            if provider.hasField(name: headerName) {
+                requestParameters.addComponentIdentifier(headerName)
+            }
+        }
+
+        if bodyDigestAlgorithm != nil {
+            let bodyDigestCreated = try generateBodyDigest(provider: provider, requestParameters: requestParameters)
+            if !bodyDigestCreated && bodyDigestRequired {
+                throw ApproovError.permanentError(message: "Failed to create required body digest")
+            }
+        }
+
+        return requestParameters
+    }
+
+    private func generateBodyDigest(provider: ApproovAsyncHTTPClientComponentProvider, requestParameters: SignatureParameters) throws -> Bool {
+        var request = provider.getRequest()
+
+        guard let body = request.body else {
+            return false
+        }
+
+        guard let bodyDigestAlg = bodyDigestAlgorithm else {
+            return false
+        }
+
+        let digest: Data
+        switch bodyDigestAlg {
+        case ApproovDefaultMessageSigning.DIGEST_SHA256:
+            digest = ApproovDefaultMessageSigning.sha256(data: body)
+        case ApproovDefaultMessageSigning.DIGEST_SHA512:
+            digest = SignatureParametersFactory.sha512(data: body)
+        default:
+            throw ApproovError.permanentError(message: "Unsupported body digest algorithm: \(bodyDigestAlg)")
+        }
+
+        do {
+            guard let digestHeader = try SFV.serializeDictionary(key: bodyDigestAlg, data: digest) else {
+                throw ApproovError.permanentError(message: "Failed to serialize Content-Digest header")
+            }
+            request.headers.add(name: "Content-Digest", value: digestHeader)
+            provider.setRequest(request)
+        } catch let error {
+            throw ApproovError.permanentError(message: "Failed to serialize Content-Digest header: \(error)")
+        }
+        requestParameters.addComponentIdentifier("Content-Digest")
+        return true
+    }
+
+    private static func sha512(data: Data) -> Data {
+        var hash = [UInt8](repeating: 0,  count: Int(CC_SHA512_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA512($0.baseAddress, CC_LONG(data.count), &hash)
+        }
+        return Data(hash)
+    }
+}
+
+/**
+ * ApproovAsyncHTTPClientComponentProvider implements the ComponentProvider protocol for AsyncHTTPClient requests.
+ */
+class ApproovAsyncHTTPClientComponentProvider: ComponentProvider {
+
+    private var request: ApproovRequest
+
+    init(request: ApproovRequest) {
+        self.request = request
+    }
+
+    public func getRequest() -> ApproovRequest {
+        return request
+    }
+
+    public func setRequest(_ newRequest: ApproovRequest) {
+        self.request = newRequest
+    }
+
+    public func getMethod() -> String {
+        return request.method
+    }
+
+    public func getAuthority() -> String {
+        return request.url.host ?? ""
+    }
+
+    public func getScheme() -> String {
+        return request.url.scheme ?? "http"
+    }
+
+    public func getTargetUri() -> String {
+        return request.url.absoluteString
+    }
+
+    public func getRequestTarget() -> String {
+        var target = getPath()
+        if let query = request.url.query {
+            target += "?\(query)"
+        }
+        return target
+    }
+
+    public func getPath() -> String {
+        return request.url.path
+    }
+
+    public func getQuery() -> String {
+        return request.url.query ?? ""
+    }
+
+    public func getQueryParam(name: String) -> String? {
+        guard let components = URLComponents(url: request.url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            return nil
+        }
+        let values = queryItems.filter { $0.name == name }.compactMap { $0.value }
+        if values.count > 1 {
+            return nil
+        }
+        return values.first
+    }
+
+    public func hasField(name: String) -> Bool {
+        return request.headers.first(name: name) != nil
+    }
+
+    public func getField(name: String) -> String? {
+        let values = request.headers[name]
+        guard !values.isEmpty else {
+            return nil
+        }
+        return ApproovAsyncHTTPClientComponentProvider.combineFieldValues(fields: values)
+    }
+
+    public func hasBody() -> Bool {
+        return request.body != nil
+    }
+}

--- a/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
@@ -133,9 +133,17 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
                 return request
             }
 
-            // Build the signature base
+            // Build the signature base. A failure here is fail-open (proceed unsigned + log at error).
             let baseBuilder = SignatureBaseBuilder(sigParams: params, ctx: provider)
-            let message = try baseBuilder.createSignatureBase()
+            let message: String
+            do {
+                message = try baseBuilder.createSignatureBase()
+            } catch {
+                if ApproovService.loggingLevel >= .error {
+                    os_log("ApproovService: failed to build the signature base, skipping signing: %@", type: .error, error.localizedDescription)
+                }
+                return provider.getRequest()
+            }
             // WARNING never log the message as it contains an Approov token which provides access to your API.
 
             // Generate the signature
@@ -183,12 +191,25 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
                 throw ApproovError.permanentError(message: "Unsupported algorithm identifier: \(params.getAlg() ?? "unknown")")
             }
 
-            // Create signature headers
-            guard let sigHeader = try SFV.serializeDictionary(key: sigId, data: signature) else {
-                throw ApproovError.permanentError(message: "Failed to serialize signature header")
-            }
-            guard let sigInputHeader = try SFV.serializeDictionary(key: sigId, innerList: params.toComponentValue()) else {
-                throw ApproovError.permanentError(message: "Failed to serialize signature input header")
+            // Create signature headers. Serialization failure (a thrown error or a nil result) is
+            // fail-open: proceed unsigned and log at error level rather than aborting the request.
+            let sigHeader: String
+            let sigInputHeader: String
+            do {
+                guard let sh = try SFV.serializeDictionary(key: sigId, data: signature),
+                      let sih = try SFV.serializeDictionary(key: sigId, innerList: params.toComponentValue()) else {
+                    if ApproovService.loggingLevel >= .error {
+                        os_log("ApproovService: failed to serialize signature headers, skipping signing", type: .error)
+                    }
+                    return provider.getRequest()
+                }
+                sigHeader = sh
+                sigInputHeader = sih
+            } catch {
+                if ApproovService.loggingLevel >= .error {
+                    os_log("ApproovService: failed to serialize signature headers, skipping signing: %@", type: .error, error.localizedDescription)
+                }
+                return provider.getRequest()
             }
 
             // Add headers to the request. Use replaceOrAdd so that re-processing an already-signed
@@ -199,7 +220,7 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
 
             if params.isDebugMode() {
                 let digest = ApproovDefaultMessageSigning.sha256(data: Data(message.utf8))
-                if let sigBaseDigestHeader = try SFV.serializeDictionary(key: "sha-256", data: digest) {
+                if let sigBaseDigestHeader = (try? SFV.serializeDictionary(key: "sha-256", data: digest)) ?? nil {
                     signedRequest.headers.replaceOrAdd(name: "Signature-Base-Digest", value: sigBaseDigestHeader)
                 } else {
                     if ApproovService.loggingLevel >= .debug {

--- a/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
@@ -212,8 +212,13 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
     }
 
     // Decode ASN.1 DER encoded ES256 signature into "raw" signature format
-    private static func decodeASN_1_DER_ES256_Signature(_ signature: Data) throws -> Data {
+    static func decodeASN_1_DER_ES256_Signature(_ signature: Data) throws -> Data {
         var offset = 0
+
+        // Ensure signature has at least 2 bytes (tag and length)
+        guard signature.count >= 2 else {
+            throw ApproovError.permanentError(message: "ASN.1 DER signature too short")
+        }
 
         // Ensure the signature starts with a valid ASN.1 sequence
         guard signature[offset] == 0x30 else {
@@ -229,6 +234,11 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
             throw ApproovError.permanentError(message: "Invalid ASN.1 DER sequence length")
         }
 
+        // Ensure there are at least 2 more bytes for r's tag and length
+        guard offset + 2 <= signature.count else {
+            throw ApproovError.permanentError(message: "Truncated ASN.1 DER signature reading r")
+        }
+
         // Decode the first integer (r)
         guard signature[offset] == 0x02 else {
             throw ApproovError.permanentError(message: "Invalid ASN.1 DER integer for r")
@@ -238,8 +248,18 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
         let rLength = Int(signature[offset])
         offset += 1
 
+        // Ensure we can read rBytes
+        guard offset + rLength <= signature.count else {
+            throw ApproovError.permanentError(message: "Truncated ASN.1 DER signature reading r value")
+        }
+
         let rBytes = signature[offset..<(offset + rLength)]
         offset += rLength
+
+        // Ensure there are at least 2 more bytes for s's tag and length
+        guard offset + 2 <= signature.count else {
+            throw ApproovError.permanentError(message: "Truncated ASN.1 DER signature reading s")
+        }
 
         // Decode the second integer (s)
         guard signature[offset] == 0x02 else {
@@ -249,6 +269,11 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
 
         let sLength = Int(signature[offset])
         offset += 1
+
+        // Ensure we can read sBytes
+        guard offset + sLength <= signature.count else {
+            throw ApproovError.permanentError(message: "Truncated ASN.1 DER signature reading s value")
+        }
 
         let sBytes = signature[offset..<(offset + sLength)]
         offset += sLength
@@ -328,11 +353,13 @@ public class SignatureParametersFactory {
     private var addApproovTraceIDHeader: Bool = false
     private var optionalHeaders: [String] = []
 
+    @discardableResult
     public func setBaseParameters(_ baseParameters: SignatureParameters) -> SignatureParametersFactory {
         self.baseParameters = baseParameters
         return self
     }
 
+    @discardableResult
     public func setBodyDigestConfig(_ bodyDigestAlgorithm: String?, required: Bool) throws -> SignatureParametersFactory {
         if let algorithm = bodyDigestAlgorithm {
             guard algorithm == ApproovDefaultMessageSigning.DIGEST_SHA256 ||
@@ -347,36 +374,43 @@ public class SignatureParametersFactory {
         return self
     }
 
+    @discardableResult
     public func setUseInstallMessageSigning() -> SignatureParametersFactory {
         self.useAccountMessageSigning = false
         return self
     }
 
+    @discardableResult
     public func setUseAccountMessageSigning() -> SignatureParametersFactory {
         self.useAccountMessageSigning = true
         return self
     }
 
+    @discardableResult
     public func setAddCreated(_ addCreated: Bool) -> SignatureParametersFactory {
         self.addCreated = addCreated
         return self
     }
 
+    @discardableResult
     public func setExpiresLifetime(_ expiresLifetime: Int64) -> SignatureParametersFactory {
         self.expiresLifetime = expiresLifetime
         return self
     }
 
+    @discardableResult
     public func setAddApproovTokenHeader(_ addApproovTokenHeader: Bool) -> SignatureParametersFactory {
         self.addApproovTokenHeader = addApproovTokenHeader
         return self
     }
 
+    @discardableResult
     public func setAddApproovTraceIDHeader(_ addApproovTraceIDHeader: Bool) -> SignatureParametersFactory {
         self.addApproovTraceIDHeader = addApproovTraceIDHeader
         return self
     }
 
+    @discardableResult
     public func addOptionalHeaders(_ headers: [String]) -> SignatureParametersFactory {
         self.optionalHeaders.append(contentsOf: headers)
         return self

--- a/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
@@ -144,36 +144,42 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
             switch params.getAlg() {
             case ApproovDefaultMessageSigning.ALG_ES256:
                 sigId = "install"
-                // A nil signature means the SDK cannot provide one (e.g. key pair generation is
-                // unavailable): this is the documented silent fallback, so proceed unsigned.
-                guard let base64Signature = ApproovService.getInstallMessageSignature(message: message) else {
+                // Message signing is fail-open: if the SDK cannot provide a usable install signature
+                // (no signature available, or a value that cannot be base64-decoded) we proceed
+                // unsigned and log at error level, rather than aborting the request.
+                guard let base64Signature = ApproovService.getInstallMessageSignature(message: message),
+                      let decodedSignature = Data(base64Encoded: base64Signature) else {
                     if ApproovService.loggingLevel >= .error {
                         os_log("ApproovService: install message signature unavailable, skipping signing", type: .error)
                     }
                     return provider.getRequest()
                 }
-                // A non-nil but undecodable signature is a real error and must be propagated.
-                guard let decodedSignature = Data(base64Encoded: base64Signature) else {
-                    throw ApproovError.permanentError(message: "Failed to base64-decode install message signature")
+                // Decode the signature from ASN.1 DER format. A malformed signature is also treated as
+                // fail-open (proceed unsigned + log) rather than aborting the request.
+                do {
+                    signature = try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(decodedSignature)
+                } catch {
+                    if ApproovService.loggingLevel >= .error {
+                        os_log("ApproovService: failed to decode ASN.1 DER install signature, skipping signing: %@",
+                               type: .error, error.localizedDescription)
+                    }
+                    return provider.getRequest()
                 }
-                // decode the signature from ASN.1 DER format
-                signature = try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(decodedSignature)
             case ApproovDefaultMessageSigning.ALG_HS256:
                 sigId = "account"
-                // A nil signature means no account signature is available yet (e.g. no mksid): this is
-                // the documented silent fallback, so proceed unsigned.
-                guard let base64Signature = ApproovService.getAccountMessageSignature(message: message) else {
+                // Fail-open: if the SDK cannot provide a usable account signature (none available, e.g.
+                // no mksid yet, or a value that cannot be base64-decoded) we proceed unsigned and log.
+                guard let base64Signature = ApproovService.getAccountMessageSignature(message: message),
+                      let decodedSignature = Data(base64Encoded: base64Signature) else {
                     if ApproovService.loggingLevel >= .error {
                         os_log("ApproovService: account message signature unavailable, skipping signing", type: .error)
                     }
                     return provider.getRequest()
                 }
-                // A non-nil but undecodable signature is a real error and must be propagated.
-                guard let decodedSignature = Data(base64Encoded: base64Signature) else {
-                    throw ApproovError.permanentError(message: "Failed to base64-decode account message signature")
-                }
                 signature = decodedSignature
             default:
+                // Unsupported algorithm is a configuration error and is the one signing failure (with a
+                // required body digest) that fails closed.
                 throw ApproovError.permanentError(message: "Unsupported algorithm identifier: \(params.getAlg() ?? "unknown")")
             }
 

--- a/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
@@ -369,6 +369,8 @@ public class SignatureParametersFactory {
             self.bodyDigestAlgorithm = algorithm
             self.bodyDigestRequired = required
         } else {
+            // Passing a nil algorithm disables body digest generation entirely.
+            self.bodyDigestAlgorithm = nil
             self.bodyDigestRequired = false
         }
         return self

--- a/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift
@@ -144,23 +144,33 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
             switch params.getAlg() {
             case ApproovDefaultMessageSigning.ALG_ES256:
                 sigId = "install"
-                guard let base64Signature = ApproovService.getInstallMessageSignature(message: message),
-                      let decodedSignature = Data(base64Encoded: base64Signature) else {
+                // A nil signature means the SDK cannot provide one (e.g. key pair generation is
+                // unavailable): this is the documented silent fallback, so proceed unsigned.
+                guard let base64Signature = ApproovService.getInstallMessageSignature(message: message) else {
                     if ApproovService.loggingLevel >= .error {
                         os_log("ApproovService: install message signature unavailable, skipping signing", type: .error)
                     }
                     return provider.getRequest()
                 }
+                // A non-nil but undecodable signature is a real error and must be propagated.
+                guard let decodedSignature = Data(base64Encoded: base64Signature) else {
+                    throw ApproovError.permanentError(message: "Failed to base64-decode install message signature")
+                }
                 // decode the signature from ASN.1 DER format
                 signature = try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(decodedSignature)
             case ApproovDefaultMessageSigning.ALG_HS256:
                 sigId = "account"
-                guard let base64Signature = ApproovService.getAccountMessageSignature(message: message),
-                      let decodedSignature = Data(base64Encoded: base64Signature) else {
+                // A nil signature means no account signature is available yet (e.g. no mksid): this is
+                // the documented silent fallback, so proceed unsigned.
+                guard let base64Signature = ApproovService.getAccountMessageSignature(message: message) else {
                     if ApproovService.loggingLevel >= .error {
                         os_log("ApproovService: account message signature unavailable, skipping signing", type: .error)
                     }
                     return provider.getRequest()
+                }
+                // A non-nil but undecodable signature is a real error and must be propagated.
+                guard let decodedSignature = Data(base64Encoded: base64Signature) else {
+                    throw ApproovError.permanentError(message: "Failed to base64-decode account message signature")
                 }
                 signature = decodedSignature
             default:
@@ -175,15 +185,16 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
                 throw ApproovError.permanentError(message: "Failed to serialize signature input header")
             }
 
-            // Add headers to the request
+            // Add headers to the request. Use replaceOrAdd so that re-processing an already-signed
+            // request does not emit duplicate Signature / Signature-Input header lines.
             var signedRequest = provider.getRequest()
-            signedRequest.headers.add(name: "Signature", value: sigHeader)
-            signedRequest.headers.add(name: "Signature-Input", value: sigInputHeader)
+            signedRequest.headers.replaceOrAdd(name: "Signature", value: sigHeader)
+            signedRequest.headers.replaceOrAdd(name: "Signature-Input", value: sigInputHeader)
 
             if params.isDebugMode() {
                 let digest = ApproovDefaultMessageSigning.sha256(data: Data(message.utf8))
                 if let sigBaseDigestHeader = try SFV.serializeDictionary(key: "sha-256", data: digest) {
-                    signedRequest.headers.add(name: "Signature-Base-Digest", value: sigBaseDigestHeader)
+                    signedRequest.headers.replaceOrAdd(name: "Signature-Base-Digest", value: sigBaseDigestHeader)
                 } else {
                     if ApproovService.loggingLevel >= .debug {
                         os_log("ApproovService: Failed to get digest algorithm - no debug entry", type: .debug)
@@ -486,7 +497,7 @@ public class SignatureParametersFactory {
             guard let digestHeader = try SFV.serializeDictionary(key: bodyDigestAlg, data: digest) else {
                 throw ApproovError.permanentError(message: "Failed to serialize Content-Digest header")
             }
-            request.headers.add(name: "Content-Digest", value: digestHeader)
+            request.headers.replaceOrAdd(name: "Content-Digest", value: digestHeader)
             provider.setRequest(request)
         } catch let error {
             throw ApproovError.permanentError(message: "Failed to serialize Content-Digest header: \(error)")
@@ -548,6 +559,12 @@ class ApproovAsyncHTTPClientComponentProvider: ComponentProvider {
     }
 
     public func getPath() -> String {
+        // RFC 9421 derived components use the on-wire (percent-encoded) path, whereas URL.path is
+        // percent-decoded. Prefer the encoded form so the server reconstructs the same signature base.
+        if let encodedPath = URLComponents(url: request.url, resolvingAgainstBaseURL: false)?.percentEncodedPath,
+           !encodedPath.isEmpty {
+            return encodedPath
+        }
         return request.url.path
     }
 

--- a/Sources/ApproovAsyncHTTPClient/ApproovHTTPClient.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovHTTPClient.swift
@@ -423,7 +423,7 @@ public class ApproovHTTPClient {
             httpClientDelegate: httpClientDelegate,
             request: request,
             delegate: delegate,
-            eventLoopPreference: .indifferent,
+            eventLoopPreference: EventLoopPreference(eventLoopPreference),
             deadline: deadline,
             logger: originalLogger ?? ApproovHTTPClient.loggingDisabled)
         task.runInBackground()
@@ -432,20 +432,7 @@ public class ApproovHTTPClient {
 
     /// Update a request for Approov
     private static func approovUpdateRequest(request: HTTPClient.Request) throws -> HTTPClient.Request {
-        var bodyData: Data? = nil
-        if let requestBody = request.body {
-            let eventLoop = EmbeddedEventLoop()
-            let writer = HTTPClient.Body.StreamWriter { ioData in
-                switch ioData {
-                case .byteBuffer(let buffer):
-                    bodyData = buffer.getData(at: 0, length: buffer.readableBytes)
-                default:
-                    break
-                }
-                return eventLoop.makeSucceededFuture(())
-            }
-            _ = requestBody.stream(writer)
-        }
+        let bodyData = extractBodyData(from: request.body)
         
         let approovReq = ApproovRequest(
             url: request.url,
@@ -484,20 +471,7 @@ public class ApproovHTTPClient {
         guard let reqURL = URL(string: url) else {
             throw HTTPClientError.invalidURL
         }
-        var bodyData: Data? = nil
-        if let requestBody = body {
-            let eventLoop = EmbeddedEventLoop()
-            let writer = HTTPClient.Body.StreamWriter { ioData in
-                switch ioData {
-                case .byteBuffer(let buffer):
-                    bodyData = buffer.getData(at: 0, length: buffer.readableBytes)
-                default:
-                    break
-                }
-                return eventLoop.makeSucceededFuture(())
-            }
-            _ = requestBody.stream(writer)
-        }
+        let bodyData = extractBodyData(from: body)
         
         let approovReq = ApproovRequest(
             url: reqURL,
@@ -572,7 +546,7 @@ extension ApproovHTTPClient {
             url: url,
             method: request.method.rawValue,
             headers: request.headers,
-            body: nil // Request body is streaming/AsyncSequence, skip digestion
+            body: extractBodyData(from: request.body)
         )
         
         let response = ApproovService.updateRequestWithApproov(request: approovReq)
@@ -592,6 +566,71 @@ extension ApproovHTTPClient {
         case .ShouldFail:
             throw ApproovError.permanentError(message: "Token fetch for \(url.host ?? ""): \(response.sdkMessage)")
         }
+    }
+
+    private static func extractBodyData(from body: HTTPClient.Body?) -> Data? {
+        guard let body = body else { return nil }
+        let eventLoop = EmbeddedEventLoop()
+        var accumulated = Data()
+        let writer = HTTPClient.Body.StreamWriter { ioData in
+            switch ioData {
+            case .byteBuffer(var buffer):
+                if let bytes = buffer.readBytes(length: buffer.readableBytes) {
+                    accumulated.append(contentsOf: bytes)
+                }
+            default:
+                break
+            }
+            return eventLoop.makeSucceededFuture(())
+        }
+        _ = body.stream(writer)
+        return accumulated
+    }
+
+    private static func extractBodyData(from body: HTTPClientRequest.Body?) -> Data? {
+        guard let body = body else { return nil }
+        let mirror = Mirror(reflecting: body)
+        for child in mirror.children {
+            if child.label == "mode" {
+                let modeMirror = Mirror(reflecting: child.value)
+                guard modeMirror.displayStyle == .enum, let caseLabel = modeMirror.children.first?.label else {
+                    continue
+                }
+                if caseLabel == "byteBuffer", let byteBuffer = modeMirror.children.first?.value as? ByteBuffer {
+                    return byteBuffer.getData(at: 0, length: byteBuffer.readableBytes)
+                } else if caseLabel == "sequence" {
+                    let associatedValue = modeMirror.children.first!.value
+                    let assocMirror = Mirror(reflecting: associatedValue)
+                    var canBeConsumedMultipleTimes = false
+                    var closure: ((ByteBufferAllocator) -> ByteBuffer)? = nil
+                    
+                    let childrenArray = Array(assocMirror.children)
+                    if childrenArray.count >= 3 {
+                        if let flag = childrenArray[1].value as? Bool {
+                            canBeConsumedMultipleTimes = flag
+                        }
+                        if let val = childrenArray[2].value as? (ByteBufferAllocator) -> ByteBuffer {
+                            closure = val
+                        }
+                    } else {
+                        for assocChild in assocMirror.children {
+                            if assocChild.label == "canBeConsumedMultipleTimes", let value = assocChild.value as? Bool {
+                                canBeConsumedMultipleTimes = value
+                            } else if let val = assocChild.value as? (ByteBufferAllocator) -> ByteBuffer {
+                                closure = val
+                            }
+                        }
+                    }
+                    
+                    if canBeConsumedMultipleTimes, let closure = closure {
+                        let allocator = ByteBufferAllocator()
+                        let byteBuffer = closure(allocator)
+                        return byteBuffer.getData(at: 0, length: byteBuffer.readableBytes)
+                    }
+                }
+            }
+        }
+        return nil
     }
 }
 
@@ -772,8 +811,31 @@ extension ApproovHTTPClient {
             self.preference = preference
         }
 
+        /// Initializer mapping from HTTPClient.EventLoopPreference using reflection
+        public init(_ httpClientPreference: HTTPClient.EventLoopPreference) {
+            let mirror = Mirror(reflecting: httpClientPreference)
+            for child in mirror.children {
+                if child.label == "preference" {
+                    let prefMirror = Mirror(reflecting: child.value)
+                    if prefMirror.displayStyle == .enum, let caseLabel = prefMirror.children.first?.label {
+                        if caseLabel == "indifferent" {
+                            self.preference = .indifferent
+                            return
+                        } else if caseLabel == "delegate", let eventLoop = prefMirror.children.first?.value as? EventLoop {
+                            self.preference = .delegate(on: eventLoop)
+                            return
+                        } else if caseLabel == "delegateAndChannel", let eventLoop = prefMirror.children.first?.value as? EventLoop {
+                            self.preference = .delegateAndChannel(on: eventLoop)
+                            return
+                        }
+                    }
+                }
+            }
+            self.preference = .indifferent
+        }
+
         /// Event Loop will be selected by the library.
-        public static let indifferent = EventLoopPreference(.indifferent)
+        public static let indifferent = EventLoopPreference(Preference.indifferent)
 
         /// The delegate will be run on the specified EventLoop (and the Channel if possible).
         ///
@@ -781,7 +843,7 @@ extension ApproovHTTPClient {
         /// `EventLoop` but will not establish a new network connection just to satisfy the `EventLoop` preference if
         /// another existing connection on a different `EventLoop` is readily available from a connection pool.
         public static func delegate(on eventLoop: EventLoop) -> EventLoopPreference {
-            return EventLoopPreference(.delegate(on: eventLoop))
+            return EventLoopPreference(Preference.delegate(on: eventLoop))
         }
 
         /// The delegate and the `Channel` will be run on the specified EventLoop.
@@ -789,7 +851,7 @@ extension ApproovHTTPClient {
         /// Use this for use-cases where you prefer a new connection to be established over re-using an existing
         /// connection that might be on a different `EventLoop`.
         public static func delegateAndChannel(on eventLoop: EventLoop) -> EventLoopPreference {
-            return EventLoopPreference(.delegateAndChannel(on: eventLoop))
+            return EventLoopPreference(Preference.delegateAndChannel(on: eventLoop))
         }
 
         /// The value of the wrapped HTTPClient.EventLoopPreference

--- a/Sources/ApproovAsyncHTTPClient/ApproovHTTPClient.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovHTTPClient.swift
@@ -432,7 +432,7 @@ public class ApproovHTTPClient {
 
     /// Update a request for Approov
     private static func approovUpdateRequest(request: HTTPClient.Request) throws -> HTTPClient.Request {
-        let bodyData = extractBodyData(from: request.body)
+        let bodyData = ApproovService.extractBodyData(from: request.body)
         
         let approovReq = ApproovRequest(
             url: request.url,
@@ -471,8 +471,8 @@ public class ApproovHTTPClient {
         guard let reqURL = URL(string: url) else {
             throw HTTPClientError.invalidURL
         }
-        let bodyData = extractBodyData(from: body)
-        
+        let bodyData = ApproovService.extractBodyData(from: body)
+
         let approovReq = ApproovRequest(
             url: reqURL,
             method: method.rawValue,
@@ -566,25 +566,6 @@ extension ApproovHTTPClient {
         case .ShouldFail:
             throw ApproovError.permanentError(message: "Token fetch for \(url.host ?? ""): \(response.sdkMessage)")
         }
-    }
-
-    private static func extractBodyData(from body: HTTPClient.Body?) -> Data? {
-        guard let body = body else { return nil }
-        let eventLoop = EmbeddedEventLoop()
-        var accumulated = Data()
-        let writer = HTTPClient.Body.StreamWriter { ioData in
-            switch ioData {
-            case .byteBuffer(var buffer):
-                if let bytes = buffer.readBytes(length: buffer.readableBytes) {
-                    accumulated.append(contentsOf: bytes)
-                }
-            default:
-                break
-            }
-            return eventLoop.makeSucceededFuture(())
-        }
-        _ = body.stream(writer)
-        return accumulated
     }
 
     private static func extractBodyData(from body: HTTPClientRequest.Body?) -> Data? {
@@ -719,11 +700,23 @@ extension ApproovHTTPClient {
                         eventLoop: self.eventLoopPreference.httpClientEventLoopPreference,
                         deadline: self.deadline,
                         logger: self.logger)
-                    self.lock.withLock {
+                    // Store the task and re-check cancellation under the same lock to close the race
+                    // where cancel() arrives between the check above and the task being stored: such a
+                    // cancel() would otherwise read a nil task and the request would run uncancelled.
+                    let cancelledBeforeStore = self.lock.withLock { () -> Bool in
+                        if self._isCancelled {
+                            return true
+                        }
                         self._httpClientTask = httpClientTask
+                        return false
+                    }
+                    if cancelledBeforeStore {
+                        httpClientTask.cancel()
+                        self.promise.fail(HTTPClientError.cancelled)
+                        return
                     }
                     // Set up the promise to complete when the wrapped HTTPClient.Task's promise completes
-                    self._httpClientTask!.futureResult.whenComplete { result in
+                    httpClientTask.futureResult.whenComplete { result in
                         switch result {
                         case .failure(let error):
                             self.promise.fail(error)

--- a/Sources/ApproovAsyncHTTPClient/ApproovHTTPClient.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovHTTPClient.swift
@@ -611,6 +611,8 @@ extension ApproovHTTPClient {
                 }
             }
         }
+        // Either a one-shot/streaming body (correctly skipped) or the AsyncHTTPClient body layout
+        // changed and reflection no longer matches. In both cases no body digest will be generated.
         return nil
     }
 }
@@ -824,6 +826,9 @@ extension ApproovHTTPClient {
                     }
                 }
             }
+            // The reflection above relies on AsyncHTTPClient internals; if its shape ever changes we
+            // cannot map the preference and fall back to .indifferent. This is a known limitation of
+            // bridging the wrapped client's EventLoopPreference.
             self.preference = .indifferent
         }
 

--- a/Sources/ApproovAsyncHTTPClient/ApproovHTTPClient.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovHTTPClient.swift
@@ -21,6 +21,7 @@ import Foundation
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
+import NIOEmbedded
 import NIOHTTP1
 import NIOHTTPCompression
 import NIOPosix
@@ -431,15 +432,47 @@ public class ApproovHTTPClient {
 
     /// Update a request for Approov
     private static func approovUpdateRequest(request: HTTPClient.Request) throws -> HTTPClient.Request {
-        let (updatedURL, updatedHeaders) = try ApproovService.updateRequest(url: request.url, headers: request.headers)
-        // Return the modified request
-        return try HTTPClient.Request(
-            url: updatedURL,
-            method: request.method,
-            headers: updatedHeaders,
-            body: request.body,
-            tlsConfiguration: nil /* request specific TLS configuration is always unused */
+        var bodyData: Data? = nil
+        if let requestBody = request.body {
+            let eventLoop = EmbeddedEventLoop()
+            let writer = HTTPClient.Body.StreamWriter { ioData in
+                switch ioData {
+                case .byteBuffer(let buffer):
+                    bodyData = buffer.getData(at: 0, length: buffer.readableBytes)
+                default:
+                    break
+                }
+                return eventLoop.makeSucceededFuture(())
+            }
+            _ = requestBody.stream(writer)
+        }
+        
+        let approovReq = ApproovRequest(
+            url: request.url,
+            method: request.method.rawValue,
+            headers: request.headers,
+            body: bodyData
         )
+        
+        let response = ApproovService.updateRequestWithApproov(request: approovReq)
+        if let error = response.error {
+            throw error
+        }
+        
+        switch response.decision {
+        case .ShouldProceed, .ShouldIgnore:
+            return try HTTPClient.Request(
+                url: response.request.url,
+                method: request.method,
+                headers: response.request.headers,
+                body: request.body,
+                tlsConfiguration: request.tlsConfiguration
+            )
+        case .ShouldRetry:
+            throw ApproovError.networkingError(message: "Token fetch for \(request.url.host ?? ""): \(response.sdkMessage)")
+        case .ShouldFail:
+            throw ApproovError.permanentError(message: "Token fetch for \(request.url.host ?? ""): \(response.sdkMessage)")
+        }
     }
 
     /// Update a request for Approov
@@ -448,19 +481,50 @@ public class ApproovHTTPClient {
         method: HTTPMethod,
         body: HTTPClient.Body?
     ) throws -> HTTPClient.Request {
-        var updatedURLString = url
-        var updatedHeaders: HTTPHeaders = HTTPHeaders()
-        if var updatedURL: URL = URL(string: url) {
-            (updatedURL, updatedHeaders) = try ApproovService.updateRequest(url: updatedURL, headers: updatedHeaders)
-            updatedURLString = updatedURL.absoluteString
+        guard let reqURL = URL(string: url) else {
+            throw HTTPClientError.invalidURL
         }
-        return try HTTPClient.Request(
-            url: updatedURLString,
-            method: method,
-            headers: updatedHeaders,
-            body: body,
-            tlsConfiguration: nil /* request specific TLS configuration is always unused */
+        var bodyData: Data? = nil
+        if let requestBody = body {
+            let eventLoop = EmbeddedEventLoop()
+            let writer = HTTPClient.Body.StreamWriter { ioData in
+                switch ioData {
+                case .byteBuffer(let buffer):
+                    bodyData = buffer.getData(at: 0, length: buffer.readableBytes)
+                default:
+                    break
+                }
+                return eventLoop.makeSucceededFuture(())
+            }
+            _ = requestBody.stream(writer)
+        }
+        
+        let approovReq = ApproovRequest(
+            url: reqURL,
+            method: method.rawValue,
+            headers: HTTPHeaders(),
+            body: bodyData
         )
+        
+        let response = ApproovService.updateRequestWithApproov(request: approovReq)
+        if let error = response.error {
+            throw error
+        }
+        
+        switch response.decision {
+        case .ShouldProceed, .ShouldIgnore:
+            return try HTTPClient.Request(
+                url: response.request.url,
+                method: method,
+                headers: response.request.headers,
+                body: body,
+                tlsConfiguration: nil
+            )
+        case .ShouldRetry:
+            throw ApproovError.networkingError(message: "Token fetch for \(reqURL.host ?? ""): \(response.sdkMessage)")
+        case .ShouldFail:
+            throw ApproovError.permanentError(message: "Token fetch for \(reqURL.host ?? ""): \(response.sdkMessage)")
+        }
     }
 }
 
@@ -500,18 +564,34 @@ extension ApproovHTTPClient {
 
     /// Update a request for Approov
     private static func approovUpdateRequest(request: HTTPClientRequest) async throws -> HTTPClientRequest {
-        var updatedURLString = request.url
-        var updatedHeaders: HTTPHeaders = request.headers
-        if var updatedURL: URL = URL(string: request.url) {
-            (updatedURL, updatedHeaders) = try ApproovService.updateRequest(url: updatedURL, headers: updatedHeaders)
-            updatedURLString = updatedURL.absoluteString
+        guard let url = URL(string: request.url) else {
+            throw HTTPClientError.invalidURL
         }
-        // Return the modified request
-        var newRequest = HTTPClientRequest(url: updatedURLString)
-        newRequest.method = request.method
-        newRequest.headers = updatedHeaders
-        newRequest.body = request.body
-        return newRequest
+        
+        let approovReq = ApproovRequest(
+            url: url,
+            method: request.method.rawValue,
+            headers: request.headers,
+            body: nil // Request body is streaming/AsyncSequence, skip digestion
+        )
+        
+        let response = ApproovService.updateRequestWithApproov(request: approovReq)
+        if let error = response.error {
+            throw error
+        }
+        
+        switch response.decision {
+        case .ShouldProceed, .ShouldIgnore:
+            var newRequest = HTTPClientRequest(url: response.request.url.absoluteString)
+            newRequest.method = request.method
+            newRequest.headers = response.request.headers
+            newRequest.body = request.body
+            return newRequest
+        case .ShouldRetry:
+            throw ApproovError.networkingError(message: "Token fetch for \(url.host ?? ""): \(response.sdkMessage)")
+        case .ShouldFail:
+            throw ApproovError.permanentError(message: "Token fetch for \(url.host ?? ""): \(response.sdkMessage)")
+        }
     }
 }
 

--- a/Sources/ApproovAsyncHTTPClient/ApproovPinningVerifier.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovPinningVerifier.swift
@@ -80,23 +80,14 @@ public class ApproovPinningVerifier {
         let serverNameOption = sec_protocol_metadata_get_server_name(sec_protocol_metadata)
         if let serverNamePointer = serverNameOption {
             let serverName = String(cString: UnsafePointer<CChar>(serverNamePointer))
-            // TEMPORARY DIAGNOSTIC (remove after pinning investigation): NSLog is used (not os_log) so it
-            // is written to stderr and visible in the test console even when ApproovService.loggingLevel
-            // is .off. If this line never appears for a connection that should have been pinned, the
-            // verify block was skipped (e.g. TLS session resumption) and the cause is outside
-            // ApproovPinningVerifier.
-            NSLog("ApproovService[PIN-DIAG]: verifyPinning invoked host=%@ peerCertCount=%d", serverName, certChain.count)
             do {
                 let isPinned = try ApproovPinningVerifier.verifyPinning(hostname: serverName, certChain: certChain)
-                NSLog("ApproovService[PIN-DIAG]: verifyPinning result host=%@ isPinned=%d", serverName, isPinned ? 1 : 0)
                 return isPinned
             } catch {
                 os_log("ApproovService: Pinning rejection for %@. %@", type: .error, serverName, error.localizedDescription)
                 return false
             }
         } else {
-            // TEMPORARY DIAGNOSTIC (remove after pinning investigation).
-            NSLog("ApproovService[PIN-DIAG]: verifyPinning invoked with no server name; rejecting")
             return false
         }
     }
@@ -135,10 +126,6 @@ public class ApproovPinningVerifier {
             }
         }
 
-        // TEMPORARY DIAGNOSTIC (remove after pinning investigation).
-        NSLog("ApproovService[PIN-DIAG]: trust evaluation passed host=%@ approovEnabled=%d",
-              hostname, ApproovService.isApproovEnabled() ? 1 : 0)
-
         // If Approov is not enabled, dynamic pinning is bypassed but basic TLS evaluation must succeed
         if !ApproovService.isApproovEnabled() {
             return true
@@ -168,10 +155,6 @@ public class ApproovPinningVerifier {
         guard let approovCertHashes = Approov.getPins("public-key-sha256") else {
             throw ApproovError.pinningError(message: "Approov SDK getPins() call failed")
         }
-        
-        // TEMPORARY DIAGNOSTIC (remove after pinning investigation).
-        NSLog("ApproovService[PIN-DIAG]: hasApproovPinMatch host=%@ hostPinCount=%d wildcardPresent=%d",
-              host, approovCertHashes[host]?.count ?? -1, approovCertHashes["*"] != nil ? 1 : 0)
 
         // Get the receivers host
         guard var certHashesBase64 = approovCertHashes[host] else {

--- a/Sources/ApproovAsyncHTTPClient/ApproovPinningVerifier.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovPinningVerifier.swift
@@ -80,14 +80,23 @@ public class ApproovPinningVerifier {
         let serverNameOption = sec_protocol_metadata_get_server_name(sec_protocol_metadata)
         if let serverNamePointer = serverNameOption {
             let serverName = String(cString: UnsafePointer<CChar>(serverNamePointer))
+            // TEMPORARY DIAGNOSTIC (remove after pinning investigation): NSLog is used (not os_log) so it
+            // is written to stderr and visible in the test console even when ApproovService.loggingLevel
+            // is .off. If this line never appears for a connection that should have been pinned, the
+            // verify block was skipped (e.g. TLS session resumption) and the cause is outside
+            // ApproovPinningVerifier.
+            NSLog("ApproovService[PIN-DIAG]: verifyPinning invoked host=%@ peerCertCount=%d", serverName, certChain.count)
             do {
                 let isPinned = try ApproovPinningVerifier.verifyPinning(hostname: serverName, certChain: certChain)
+                NSLog("ApproovService[PIN-DIAG]: verifyPinning result host=%@ isPinned=%d", serverName, isPinned ? 1 : 0)
                 return isPinned
             } catch {
                 os_log("ApproovService: Pinning rejection for %@. %@", type: .error, serverName, error.localizedDescription)
                 return false
             }
         } else {
+            // TEMPORARY DIAGNOSTIC (remove after pinning investigation).
+            NSLog("ApproovService[PIN-DIAG]: verifyPinning invoked with no server name; rejecting")
             return false
         }
     }
@@ -125,6 +134,10 @@ public class ApproovPinningVerifier {
                     message: "Error: Certificate Trust Evaluation failure for host \(hostname)")
             }
         }
+
+        // TEMPORARY DIAGNOSTIC (remove after pinning investigation).
+        NSLog("ApproovService[PIN-DIAG]: trust evaluation passed host=%@ approovEnabled=%d",
+              hostname, ApproovService.isApproovEnabled() ? 1 : 0)
 
         // If Approov is not enabled, dynamic pinning is bypassed but basic TLS evaluation must succeed
         if !ApproovService.isApproovEnabled() {
@@ -198,6 +211,10 @@ public class ApproovPinningVerifier {
             throw ApproovError.pinningError(message: "Approov SDK getPins() call failed")
         }
         
+        // TEMPORARY DIAGNOSTIC (remove after pinning investigation).
+        NSLog("ApproovService[PIN-DIAG]: hasApproovPinMatch host=%@ hostPinCount=%d wildcardPresent=%d",
+              host, approovCertHashes[host]?.count ?? -1, approovCertHashes["*"] != nil ? 1 : 0)
+
         // Get the receivers host
         guard var certHashesBase64 = approovCertHashes[host] else {
             // Host is not pinned

--- a/Sources/ApproovAsyncHTTPClient/ApproovPinningVerifier.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovPinningVerifier.swift
@@ -125,6 +125,11 @@ public class ApproovPinningVerifier {
                     message: "Error: Certificate Trust Evaluation failure for host \(hostname)")
             }
         }
+
+        // If Approov is not enabled, dynamic pinning is bypassed but basic TLS evaluation must succeed
+        if !ApproovService.isApproovEnabled() {
+            return true
+        }
         
         // Check the Approov dynamic pinning
         return try self.hasApproovPinMatch(host: hostname, certChain: certChain)
@@ -138,54 +143,54 @@ public class ApproovPinningVerifier {
      * @return Bool true if there was a pin match
      */
     static func hasApproovPinMatch(host: String, certChain: [SecCertificate]) throws -> Bool {
-        // Ensure pins are refreshed eventually
-        ApproovService.prefetch()
+        // Check if pinning should process for this host
+        if !ApproovService.getServiceMutator().handlePinningShouldProcessRequest(hostname: host) {
+            os_log("ApproovService: Pin verification for %@ bypassed by service mutator", type: .info, host)
+            return true
+        }
         
-        // Get the certificate chain count
+        // Retrieve the pins from Approov SDK exactly once
+        guard let approovCertHashes = Approov.getPins("public-key-sha256") else {
+            throw ApproovError.pinningError(message: "Approov SDK getPins() call failed")
+        }
+        
+        // Get the receivers host
+        guard var certHashesBase64 = approovCertHashes[host] else {
+            // Host is not pinned
+            os_log("ApproovService: Pin verification %@ unpinned", host)
+            return true
+        }
+        
+        // Check whether we have pins defined for this host
+        if certHashesBase64.count == 0 {
+            // There are no pins defined for this host, check for managed trust roots
+            if let managedTrustRootHashesBase64 = approovCertHashes["*"] {
+                certHashesBase64 = managedTrustRootHashesBase64
+            } else {
+                // There are no managed trust roots either, accept connection. We do not pin connections
+                // where no pins are explicitly set for the host.
+                os_log("ApproovService: Pin verification %@ empty pins", host)
+                return true
+            }
+        }
+        
+        // We have one or more cert hashes matching the receiver's host, compare them against the cert chain
         for cert in certChain {
             if let publicKeyInfo = publicKeyInfoOfCertificate(certificate: cert) {
                 // Compute the SHA-256 hash of the public key info
                 let publicKeyHash = sha256(data: publicKeyInfo)
-
-                // Check that the hash is the same as at least one of the pins
-                guard let approovCertHashes = Approov.getPins("public-key-sha256") else {
-                    throw ApproovError.pinningError(message: "Approov SDK getPins() call failed")
-                }
-                
-                // Get the receivers host
-                if var certHashesBase64 = approovCertHashes[host] {
-                    // Check whether we have pins defined for this host
-                    if certHashesBase64.count == 0 {
-                        // There are no pins defined for this host, check for managed trust roots
-                        if let managedTrustRootHashesBase64 = approovCertHashes["*"] {
-                            // Managed trust roots are available, so use these
-                            certHashesBase64 = managedTrustRootHashesBase64
-                        } else {
-                            // There are no managed trust roots either, accept connection. We do not pin connections
-                            // where no pins are explicitly set for the host.
-                            os_log("ApproovService: Pin verification %@ empty pins", host)
-                            return true
-                        }
+                for certHashBase64 in certHashesBase64 {
+                    let certHash = Data(base64Encoded: certHashBase64)
+                    if publicKeyHash == certHash {
+                        os_log("ApproovService: Matched pin %@ for %@ from %d pins", certHashBase64, host, certHashesBase64.count)
+                        return true
                     }
-
-                    // We have one or more cert hashes matching the receiver's host, compare them
-                    for certHashBase64 in certHashesBase64 {
-                        let certHash = Data(base64Encoded: certHashBase64)
-                        if publicKeyHash == certHash {
-                            os_log("ApproovService: Matched pin %@ for %@ from %d pins", certHashBase64, host, certHashesBase64.count)
-                            return true
-                        }
-                    }
-                } else {
-                    // Host is not pinned
-                    os_log("ApproovService: Pin verification %@ unpinned", host)
-                    return true
                 }
             } else {
                 os_log("ApproovService: Skipping pin checking for unknown certificate type")
             }
         }
-
+        
         // No match in current set of pins from Approov SDK and certificate chain seen during TLS handshake
         os_log("ApproovService: Pinning rejection for %@", type: .error, host)
         return false

--- a/Sources/ApproovAsyncHTTPClient/ApproovPinningVerifier.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovPinningVerifier.swift
@@ -130,9 +130,53 @@ public class ApproovPinningVerifier {
         if !ApproovService.isApproovEnabled() {
             return true
         }
-        
+
+        // Pin against the OS-validated certificate path rather than the raw peer-supplied chain.
+        // SecTrustEvaluateWithError only validates the path it builds to a trusted anchor; the input
+        // array may contain additional certificates that are not part of that path. An attacker holding
+        // any CA-trusted certificate for the host could otherwise append the legitimate pinned
+        // certificate as an unused decoy and have the pin match succeed against it. Extracting the
+        // evaluated chain from the trust object ensures we only compare pins against certificates that
+        // actually participate in the validated path.
+        guard let validatedChain = ApproovPinningVerifier.evaluatedCertificateChain(from: serverTrust!) else {
+            throw ApproovError.pinningError(
+                message: "Error retrieving validated certificate chain for host \(hostname)")
+        }
+
         // Check the Approov dynamic pinning
-        return try self.hasApproovPinMatch(host: hostname, certChain: certChain)
+        return try self.hasApproovPinMatch(host: hostname, certChain: validatedChain)
+    }
+
+    /**
+     * Extracts the certificate chain that was actually validated by trust evaluation.
+     *
+     * This must be called only after SecTrust evaluation has succeeded. The returned chain reflects the
+     * path SecTrust built to a trusted anchor, excluding any extra certificates the peer supplied that do
+     * not participate in that path.
+     *
+     * @param trust the evaluated SecTrust object
+     * @return the validated certificate chain, or nil if it could not be retrieved
+     */
+    static func evaluatedCertificateChain(from trust: SecTrust) -> [SecCertificate]? {
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+            guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate], !chain.isEmpty else {
+                return nil
+            }
+            return chain
+        } else {
+            let count = SecTrustGetCertificateCount(trust)
+            guard count > 0 else {
+                return nil
+            }
+            var chain: [SecCertificate] = []
+            for index in 0..<count {
+                guard let cert = SecTrustGetCertificateAtIndex(trust, index) else {
+                    return nil
+                }
+                chain.append(cert)
+            }
+            return chain
+        }
     }
 
     /**

--- a/Sources/ApproovAsyncHTTPClient/ApproovPinningVerifier.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovPinningVerifier.swift
@@ -144,52 +144,10 @@ public class ApproovPinningVerifier {
             return true
         }
 
-        // Pin against the OS-validated certificate path rather than the raw peer-supplied chain.
-        // SecTrustEvaluateWithError only validates the path it builds to a trusted anchor; the input
-        // array may contain additional certificates that are not part of that path. An attacker holding
-        // any CA-trusted certificate for the host could otherwise append the legitimate pinned
-        // certificate as an unused decoy and have the pin match succeed against it. Extracting the
-        // evaluated chain from the trust object ensures we only compare pins against certificates that
-        // actually participate in the validated path.
-        guard let validatedChain = ApproovPinningVerifier.evaluatedCertificateChain(from: serverTrust!) else {
-            throw ApproovError.pinningError(
-                message: "Error retrieving validated certificate chain for host \(hostname)")
-        }
-
-        // Check the Approov dynamic pinning
-        return try self.hasApproovPinMatch(host: hostname, certChain: validatedChain)
-    }
-
-    /**
-     * Extracts the certificate chain that was actually validated by trust evaluation.
-     *
-     * This must be called only after SecTrust evaluation has succeeded. The returned chain reflects the
-     * path SecTrust built to a trusted anchor, excluding any extra certificates the peer supplied that do
-     * not participate in that path.
-     *
-     * @param trust the evaluated SecTrust object
-     * @return the validated certificate chain, or nil if it could not be retrieved
-     */
-    static func evaluatedCertificateChain(from trust: SecTrust) -> [SecCertificate]? {
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate], !chain.isEmpty else {
-                return nil
-            }
-            return chain
-        } else {
-            let count = SecTrustGetCertificateCount(trust)
-            guard count > 0 else {
-                return nil
-            }
-            var chain: [SecCertificate] = []
-            for index in 0..<count {
-                guard let cert = SecTrustGetCertificateAtIndex(trust, index) else {
-                    return nil
-                }
-                chain.append(cert)
-            }
-            return chain
-        }
+        // Check the Approov dynamic pinning against the peer-presented certificate chain. This matches
+        // the behaviour of the other Approov service layers (which pin against the peer chain), keeping
+        // pin-matching consistent across platforms for the same Approov configuration.
+        return try self.hasApproovPinMatch(host: hostname, certChain: certChain)
     }
 
     /**

--- a/Sources/ApproovAsyncHTTPClient/ApproovService.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovService.swift
@@ -76,35 +76,45 @@ public class ApproovService {
      * Note the initializer function should only ever be called once. Subsequent calls will be ignored
      * since the ApproovSDK can only be intialized once; if however, an attempt is made to initialize
      * with a different configuration (config) we throw an ApproovError.configurationError.
-     * If the Approov SDk fails to be initialized for some other reason, an .initializationFailure is raised.
-     * The configuration string is obtained using `approov sdk -getConfigString` or through an Approov onboarding email.
+     * If the underlying SDK has already been initialized by another service layer then the SDK error
+     * is logged and ignored. If the Approov SDk fails to be initialized for some other reason, an
+     * .initializationFailure is raised. The configuration string is obtained using `approov sdk -getConfigString`
+     * or through an Approov onboarding email.
+     *
+     * @param config is the configuration to be used
+     * @param comment is an optional comment to be passed to the SDK
      */
-    public static func initialize(config: String) throws {
+    public static func initialize(config: String, comment: String? = nil) throws {
         try initLock.withLock {
             // Check if we attempt to use a different configString
-            if (approovSDKInitialised) {
-                if (config != approovConfigString) {
+            if approovSDKInitialised && ((comment?.hasPrefix("reinit")) == nil) {
+                if config != approovConfigString {
                     // Throw exception indicating we are attempting to use different config
                     let errorMessage = "Attempting to initialize with different configuration"
                     os_log("ApproovService: %@", type: .error, errorMessage)
                     throw ApproovError.configurationError(message: errorMessage)
                 }
+                os_log("ApproovService: Ignoring multiple ApproovService layer initializations with the same config")
                 return
             }
             // Initialize Approov SDK
             do {
-                try Approov.initialize(config, updateConfig: "auto", comment: nil)
-                approovConfigString = config
-                approovSDKInitialised = true
-                Approov.setUserProperty("approov-service-asynchttpclient")
-                // Set the global Approov pinning verification block for AsyncHTTPClient
-                TLSConfiguration.setVerifyPinningBlock(newValue: ApproovPinningVerifier.verifyPinning)
-            } catch let error {
-                // Log error and throw exception
-                let errorMessage = "Error initializing Approov SDK: \(error.localizedDescription)"
-                os_log("ApproovService: %@", type: .error, errorMessage)
-                throw ApproovError.initializationFailure(message: errorMessage)
+                try Approov.initialize(config, updateConfig: "auto", comment: comment)
+            } catch {
+                let nsError = error as NSError
+                if nsError.code == 0, nsError.domain == "Foundation._GenericObjCError" {
+                    os_log("ApproovService: Ignoring initialization error in Approov SDK: %@", type: .error, nsError.localizedDescription)
+                } else {
+                    let errorMessage = "Error initializing Approov SDK: \(nsError.localizedDescription)"
+                    os_log("ApproovService: %@", type: .error, errorMessage)
+                    throw ApproovError.initializationFailure(message: errorMessage)
+                }
             }
+            approovConfigString = config
+            approovSDKInitialised = true
+            Approov.setUserProperty("approov-service-asynchttpclient")
+            // Set the global Approov pinning verification block for AsyncHTTPClient
+            TLSConfiguration.setVerifyPinningBlock(newValue: ApproovPinningVerifier.verifyPinning)
         }
     }
 

--- a/Sources/ApproovAsyncHTTPClient/ApproovService.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovService.swift
@@ -384,7 +384,7 @@ public class ApproovService {
     }
 
     public static func signRequest(_ request: HTTPClient.Request) throws -> HTTPClient.Request {
-        let bodyData = try getHTTPBody(request)
+        let bodyData = extractBodyData(from: request.body)
         let approovReq = ApproovRequest(
             url: request.url,
             method: request.method.rawValue,
@@ -411,25 +411,58 @@ public class ApproovService {
         }
     }
     
-    private static func getHTTPBody(_ request: HTTPClient.Request) throws -> Data? {
-        guard let requestBody = request.body else {
+    /**
+     * Extracts the body data from an AsyncHTTPClient `HTTPClient.Body` for body-digest computation.
+     *
+     * `HTTPClient.Body` is opaque: unlike the async `HTTPClientRequest.Body` it exposes no flag
+     * indicating whether it can be consumed more than once. To avoid corrupting one-shot or
+     * asynchronous streaming uploads, the body is only buffered when it can be read non-destructively
+     * and completely: its stream closure is invoked on an isolated `EmbeddedEventLoop` and the
+     * resulting future must complete synchronously. In-memory bodies (`.byteBuffer`, `.bytes`,
+     * `.string`) satisfy this and still re-stream correctly at execution time, because reading the
+     * buffered copy does not advance the original. Chunked / one-shot / asynchronous streaming bodies
+     * are skipped (returns nil) so the request proceeds without a body digest rather than being
+     * silently truncated or consumed — matching the documented "gracefully skip one-shot uploads"
+     * behaviour for body digests.
+     *
+     * - Parameter body: the request body to inspect.
+     * - Returns: the complete body bytes if they could be buffered non-destructively; otherwise nil.
+     */
+    static func extractBodyData(from body: HTTPClient.Body?) -> Data? {
+        guard let body = body else {
             return nil
         }
-        
-        var collectedData: Data? = nil
+
+        // A nil length indicates a chunked / streaming body of unknown size; treat it as one-shot and
+        // skip it so we never start consuming an unrepeatable source.
+        if body.length == nil {
+            return nil
+        }
+
         let eventLoop = EmbeddedEventLoop()
+        var accumulated = Data()
+        var unsupportedChunk = false
         let writer = HTTPClient.Body.StreamWriter { ioData in
             switch ioData {
             case .byteBuffer(let buffer):
-                collectedData = buffer.getData(at: 0, length: buffer.readableBytes)
+                accumulated.append(contentsOf: buffer.readableBytesView)
             default:
-                break
+                // File regions and other chunk kinds cannot be digested in-memory.
+                unsupportedChunk = true
             }
             return eventLoop.makeSucceededFuture(())
         }
-        
-        _ = requestBody.stream(writer)
-        return collectedData
+
+        var completedSynchronously = false
+        let future = body.stream(writer)
+        future.whenComplete { _ in completedSynchronously = true }
+        eventLoop.run()
+
+        guard completedSynchronously, !unsupportedChunk else {
+            // Streaming / asynchronous body: do not digest a partial or consumed body.
+            return nil
+        }
+        return accumulated
     }
 
     private static func applyMutatorError(_ error: Error,

--- a/Sources/ApproovAsyncHTTPClient/ApproovService.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovService.swift
@@ -260,6 +260,41 @@ public class ApproovService {
     }
 
     /**
+     * Logs that an Approov-dependent method was invoked while the platform SDK is not active,
+     * distinguishing "initialized in bypass mode (empty config)" from "service layer not initialized
+     * at all" so the two states can be told apart in the logs.
+     */
+    private static func logApproovUnavailable(_ method: String) {
+        guard loggingLevel >= .error else {
+            return
+        }
+        let (initialized, enabled) = initLock.withLock {
+            (approovSDKInitialised, isApproovEnabledInternal)
+        }
+        if initialized && !enabled {
+            os_log("ApproovService: %@: Approov is disabled (initialized in bypass mode); ignoring call",
+                   type: .error, method)
+        } else {
+            os_log("ApproovService: %@: service layer not initialized", type: .error, method)
+        }
+    }
+
+    /**
+     * Runs a throwing operation (typically a service mutator callback) and guarantees that any error
+     * escaping is an `ApproovError`. A custom mutator may throw an arbitrary `Error`; this wraps such
+     * values as `ApproovError.permanentError` so the documented public throwing contract holds.
+     */
+    private static func wrappingApproovError<T>(_ context: String, _ body: () throws -> T) throws -> T {
+        do {
+            return try body()
+        } catch let error as ApproovError {
+            throw error
+        } catch {
+            throw ApproovError.permanentError(message: "\(context): \(error.localizedDescription)")
+        }
+    }
+
+    /**
      * Sets a flag indicating if the network interceptor should proceed anyway if it is
      * not possible to obtain an Approov token due to a networking failure.
      */
@@ -343,9 +378,7 @@ public class ApproovService {
      */
     public static func setDevKey(devKey: String) {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: setDevKey: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("setDevKey")
             return
         }
         Approov.setDevKey(devKey)
@@ -494,7 +527,9 @@ public class ApproovService {
             return nil
         }
         if (ProcessInfo.processInfo.systemUptime - time) < failureCacheTTL {
-            os_log("ApproovService: using cached failure: %@", type: .debug, Approov.string(from: result.status))
+            if loggingLevel >= .debug {
+                os_log("ApproovService: using cached failure: %@", type: .debug, Approov.string(from: result.status))
+            }
             return result
         }
         cachedFailureResult = nil
@@ -669,8 +704,8 @@ public class ApproovService {
         for (header, prefix) in subsHeadersCopy {
             if let value = allHeaders.first(name: header) {
                 if ((value.hasPrefix(prefix)) && (value.count > prefix.count)) {
-                    let index = prefix.index(prefix.startIndex, offsetBy: prefix.count)
-                    let approovResults = Approov.fetchSecureStringAndWait(String(value.suffix(from:index)), nil)
+                    let lookupKey = String(value.dropFirst(prefix.count))
+                    let approovResults = Approov.fetchSecureStringAndWait(lookupKey, nil)
                     if loggingLevel >= .info {
                         os_log("ApproovService: Substituting header: %@, %@", type: .info, header, Approov.string(from: approovResults.status))
                     }
@@ -853,8 +888,11 @@ public class ApproovService {
                     os_log("ApproovService: addExclusionURLRegex: %@", type: .debug, urlRegex)
                 }
             } catch {
-                if _loggingLevel >= .debug {
-                    os_log("ApproovService: addExclusionURLRegex: %@ error: %@", type: .debug, urlRegex, error.localizedDescription)
+                // The pattern was rejected and no exclusion was registered; surface this at error
+                // level so callers are not left believing an invalid regex took effect.
+                if _loggingLevel >= .error {
+                    os_log("ApproovService: addExclusionURLRegex: %@ rejected, exclusion NOT added: %@",
+                           type: .error, urlRegex, error.localizedDescription)
                 }
             }
         }
@@ -883,9 +921,7 @@ public class ApproovService {
      */
     public static func getDeviceID() -> String? {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: getDeviceID: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("getDeviceID")
             return nil
         }
         let deviceID = Approov.getDeviceID()
@@ -902,9 +938,7 @@ public class ApproovService {
      */
     public static func setDataHashInToken(data: String) {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: setDataHashInToken: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("setDataHashInToken")
             return
         }
         if loggingLevel >= .debug {
@@ -918,16 +952,16 @@ public class ApproovService {
      */
     public static func fetchToken(url: String) throws -> String {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: fetchToken: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("fetchToken")
             throw ApproovError.permanentError(message: "fetchToken: SDK not initialized")
         }
         let result = Approov.fetchTokenAndWait(url)
         if loggingLevel >= .debug {
             os_log("ApproovService: fetchToken: %@", type: .debug, Approov.string(from: result.status))
         }
-        try getServiceMutator().handleFetchTokenResult(result)
+        try wrappingApproovError("fetchToken") {
+            try getServiceMutator().handleFetchTokenResult(result)
+        }
         return result.token
     }
 
@@ -936,9 +970,7 @@ public class ApproovService {
      */
     public static func setInstallAttrsInToken(attrs: String) throws {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: setInstallAttrsInToken: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("setInstallAttrsInToken")
             throw ApproovError.permanentError(message: "setInstallAttrsInToken: SDK not initialized")
         }
         Approov.setInstallAttrsInToken(attrs)
@@ -952,9 +984,7 @@ public class ApproovService {
      */
     public static func getAccountMessageSignature(message: String) -> String? {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: getAccountMessageSignature: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("getAccountMessageSignature")
             return nil
         }
         return Approov.getMessageSignature(message)
@@ -965,9 +995,7 @@ public class ApproovService {
      */
     public static func getInstallMessageSignature(message: String) -> String? {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: getInstallMessageSignature: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("getInstallMessageSignature")
             return nil
         }
         return Approov.getInstallMessageSignature(message)
@@ -989,9 +1017,7 @@ public class ApproovService {
      */
     public static func fetchSecureString(key: String, newDef: String?) throws -> String? {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: fetchSecureString: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("fetchSecureString")
             throw ApproovError.permanentError(message: "fetchSecureString: SDK not initialized")
         }
         let type = newDef != nil ? "definition" : "lookup"
@@ -999,7 +1025,9 @@ public class ApproovService {
         if loggingLevel >= .info {
             os_log("ApproovService: fetchSecureString: %@: %@", type: .info, type, Approov.string(from: approovResult.status))
         }
-        try getServiceMutator().handleFetchSecureStringResult(approovResult, operation: type, key: key)
+        try wrappingApproovError("fetchSecureString \(type) for \(key)") {
+            try getServiceMutator().handleFetchSecureStringResult(approovResult, operation: type, key: key)
+        }
         return approovResult.secureString
     }
 
@@ -1008,16 +1036,16 @@ public class ApproovService {
      */
     public static func fetchCustomJWT(payload: String) throws -> String {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: fetchCustomJWT: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("fetchCustomJWT")
             throw ApproovError.permanentError(message: "fetchCustomJWT: SDK not initialized")
         }
         let approovResult = Approov.fetchCustomJWTAndWait(payload)
         if loggingLevel >= .info {
             os_log("ApproovService: fetchCustomJWT: %@", type: .info, Approov.string(from: approovResult.status))
         }
-        try getServiceMutator().handleFetchCustomJWTResult(approovResult)
+        try wrappingApproovError("fetchCustomJWT") {
+            try getServiceMutator().handleFetchCustomJWTResult(approovResult)
+        }
         return approovResult.token
     }
 
@@ -1026,9 +1054,7 @@ public class ApproovService {
      */
     public static func precheck() throws {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: precheck: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("precheck")
             throw ApproovError.permanentError(message: "precheck: SDK not initialized")
         }
         let approovResults = Approov.fetchSecureStringAndWait("precheck-dummy-key", nil)
@@ -1041,7 +1067,9 @@ public class ApproovService {
                 os_log("ApproovService: precheck: %@", type: .debug, Approov.string(from: approovResults.status))
             }
         }
-        try getServiceMutator().handlePrecheckResult(approovResults)
+        try wrappingApproovError("precheck") {
+            try getServiceMutator().handlePrecheckResult(approovResults)
+        }
     }
 
     /**
@@ -1049,9 +1077,7 @@ public class ApproovService {
      */
     public static func getLastARC() -> String {
         if !isApproovEnabled() {
-            if loggingLevel >= .error {
-                os_log("ApproovService: getLastARC: SDK not initialized", type: .error)
-            }
+            logApproovUnavailable("getLastARC")
             return ""
         }
         guard let approovPins = Approov.getPins("public-key-sha256") else {

--- a/Sources/ApproovAsyncHTTPClient/ApproovService.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovService.swift
@@ -204,7 +204,7 @@ public class ApproovService {
 
             approovSDKInitialised = true
             if isEnabled {
-                Approov.setUserProperty("approov-service-asynchttpclient")
+                Approov.setUserProperty("approov-service-asynchttpclient/3.5.4")
             }
             TLSConfiguration.setVerifyPinningBlock(newValue: ApproovPinningVerifier.verifyPinning)
         }

--- a/Sources/ApproovAsyncHTTPClient/ApproovService.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovService.swift
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import Approov
+import AsyncHTTPClient
+import NIOCore
+import NIOEmbedded
 import Foundation
 import NIOConcurrencyHelpers
 import NIOHTTP1
@@ -40,23 +43,40 @@ public enum ApproovError: Error, LocalizedError {
         get {
             switch self {
             case let .initializationFailure(message),
-                let .configurationError(message),
-                let .pinningError(message),
-                let .networkingError(message),
-                let .permanentError(message),
-                let .runtimeError(message):
+                 let .configurationError(message),
+                 let .pinningError(message),
+                 let .networkingError(message),
+                 let .permanentError(message),
+                 let .runtimeError(message):
                 return message
-            case let .rejectionError(message, _, rejectionReasons):
-                var reasons: String = ""
-                if !rejectionReasons.isEmpty {
-                    reasons += ", reasons: " + rejectionReasons
+            case let .rejectionError(message, ARC, rejectionReasons):
+                var info: String = ""
+                if ARC != "" {
+                    info += ", ARC: " + ARC
                 }
-                return message + reasons
+                if rejectionReasons != "" {
+                    info += ", reasons: " + rejectionReasons
+                }
+                return message + info
             }
         }
     }
     public var errorDescription: String? {
         return localizedDescription
+    }
+}
+
+/**
+ * Log level for controlling the verbosity of os_log output from the ApproovService
+ */
+public enum ApproovLogLevel: Int, Comparable {
+    case off = 0
+    case error = 1
+    case warning = 2
+    case info = 3
+    case debug = 4
+    public static func < (lhs: ApproovLogLevel, rhs: ApproovLogLevel) -> Bool {
+        return lhs.rawValue < rhs.rawValue
     }
 }
 
@@ -66,122 +86,32 @@ public class ApproovService {
     /** Private initializer to disallow instantiation as this is a static only class */
     fileprivate init(){}
 
-    /** Lock to manage intialization */
+    /** Lock to manage initialization */
     private static let initLock = NIOLock()
 
-    /** Status of Approov SDK initialisation */
+    /** Status of Approov SDK initialization */
     private static var approovSDKInitialised = false
 
-    /**
-     * Note the initializer function should only ever be called once. Subsequent calls will be ignored
-     * since the ApproovSDK can only be intialized once; if however, an attempt is made to initialize
-     * with a different configuration (config) we throw an ApproovError.configurationError.
-     * If the underlying SDK has already been initialized by another service layer then the SDK error
-     * is logged and ignored. If the Approov SDk fails to be initialized for some other reason, an
-     * .initializationFailure is raised. The configuration string is obtained using `approov sdk -getConfigString`
-     * or through an Approov onboarding email.
-     *
-     * @param config is the configuration to be used
-     * @param comment is an optional comment to be passed to the SDK
-     */
-    public static func initialize(config: String, comment: String? = nil) throws {
-        try initLock.withLock {
-            // Check if we attempt to use a different configString
-            if approovSDKInitialised && ((comment?.hasPrefix("reinit")) == nil) {
-                if config != approovConfigString {
-                    // Throw exception indicating we are attempting to use different config
-                    let errorMessage = "Attempting to initialize with different configuration"
-                    os_log("ApproovService: %@", type: .error, errorMessage)
-                    throw ApproovError.configurationError(message: errorMessage)
-                }
-                os_log("ApproovService: Ignoring multiple ApproovService layer initializations with the same config")
-                return
-            }
-            // Initialize Approov SDK
-            do {
-                try Approov.initialize(config, updateConfig: "auto", comment: comment)
-            } catch {
-                let nsError = error as NSError
-                if nsError.code == 0, nsError.domain == "Foundation._GenericObjCError" {
-                    os_log("ApproovService: Ignoring initialization error in Approov SDK: %@", type: .error, nsError.localizedDescription)
-                } else {
-                    let errorMessage = "Error initializing Approov SDK: \(nsError.localizedDescription)"
-                    os_log("ApproovService: %@", type: .error, errorMessage)
-                    throw ApproovError.initializationFailure(message: errorMessage)
-                }
-            }
-            approovConfigString = config
-            approovSDKInitialised = true
-            Approov.setUserProperty("approov-service-asynchttpclient")
-            // Set the global Approov pinning verification block for AsyncHTTPClient
-            TLSConfiguration.setVerifyPinningBlock(newValue: ApproovPinningVerifier.verifyPinning)
-        }
-    }
+    /** Configuration string used for initialization */
+    private static var _approovConfigString: String?
 
     /** Lock to manage variable access */
     private static let stateLock = NIOLock()
 
     /** True if the interceptor should proceed on network failures and not add an Approov token */
-    private static var _proceedOnNetworkFail = false;
+    private static var _proceedOnNetworkFail = false
 
-    /**
-     * Sets a flag indicating if the network interceptor should proceed anyway if it is
-     * not possible to obtain an Approov token due to a networking failure. If this is set
-     * then your backend API can receive calls without the expected Approov token header
-     * being added, or without header/query parameter substitutions being made. Note that
-     * this should be used with caution because it may allow a connection to be established
-     * before any dynamic pins have been received via Approov, thus potentially opening the channel to a MitM.
-     */
-    public static var proceedOnNetworkFail: Bool {
-        get {
-            var proceedOnNetworkFail = false
-            stateLock.withLock {
-                proceedOnNetworkFail = _proceedOnNetworkFail
-            }
-            return proceedOnNetworkFail
-        }
-        set {
-            stateLock.withLock {
-                _proceedOnNetworkFail = newValue
-            }
-        }
-    }
-
-    /** Map of names for headers that should have their values substituted for secure strings, mapped to their
-     * required prefixes */
+    /** Map of names for headers that should have their values substituted for secure strings, mapped to their required prefixes */
     private static var substitutionHeaders: Dictionary<String, String> = Dictionary<String, String>()
 
     /** Set of query parameters that may be substituted, specified by the key name */
-    private static var substitutionQueryParams: Set<String> = [];
+    private static var substitutionQueryParams: Set<String> = []
 
     /** Set of URL regexs that should be excluded from any Approov protection, mapped to the compiled Pattern */
-    private static var exclusionURLRegexs: Dictionary<String, NSRegularExpression> =
-    Dictionary<String, NSRegularExpression>();
+    private static var exclusionURLRegexs: Dictionary<String, NSRegularExpression> = Dictionary<String, NSRegularExpression>()
 
     /** Bind Header string */
     private static var _bindHeader = ""
-
-    /**
-     * Sets a binding header that must be present on all requests using the Approov service. A
-     * header should be chosen whose value is unchanging for most requests (such as an
-     * Authorization header). A hash of the header value is included in the issued Approov tokens
-     * to bind them to the value. This may then be verified by the backend API integration. This
-     * method should typically only be called once.
-     */
-    public static var bindHeader: String {
-        get {
-            var bindHeader = ""
-            stateLock.withLock {
-                bindHeader = _bindHeader
-            }
-            return bindHeader
-        }
-        set {
-            stateLock.withLock {
-                _bindHeader = newValue
-            }
-        }
-    }
 
     /** Approov token default header */
     private static var _approovTokenHeader = "Approov-Token"
@@ -189,270 +119,637 @@ public class ApproovService {
     /** Approov token custom prefix: any prefix to be added such as "Bearer " */
     private static var _approovTokenPrefix = ""
 
+    /** Approov TraceID optional header */
+    private static var _approovTraceIDHeader: String? = "Approov-TraceID"
+
+    /** Use Approov fetch status if token is empty */
+    private static var _useApproovStatusIfNoToken = false
+
+    /** The mutator instance used to control ApproovService behavior at key points in the flow. */
+    private static var _serviceMutator: ApproovServiceMutator = ApproovServiceMutatorDefault.shared
+
+    /** Current logging level */
+    private static var _loggingLevel: ApproovLogLevel = .info
+
+    /** Failure cache variables */
+    private static let failureCacheLock = NIOLock()
+    private static var cachedFailureResult: ApproovTokenFetchResult? = nil
+    private static var cachedFailureTime: TimeInterval? = nil
+    private static var failureCacheTTL: TimeInterval = 0.5 // seconds
+    private static var failureCacheMissGroup: DispatchGroup? = nil
+
+    public static var loggingLevel: ApproovLogLevel {
+        get {
+            stateLock.withLock { _loggingLevel }
+        }
+        set {
+            stateLock.withLock { _loggingLevel = newValue }
+        }
+    }
+
     /**
-     * Sets the header that the Approov token is added on, as well as an optional
-     * prefix String (such as "Bearer "). By default the token is provided on
-     * "Approov-Token" with no prefix.
-     *
-     * @param approovTokenHeader is the header to place the Approov token on
-     * @param approovTokenPrefix is any prefix String for the Approov token header
+     * Initializes the ApproovService with the config obtained using `approov sdk -getConfigString`
+     * or in the original onboarding email.
+     */
+    public static func initialize(config: String, comment: String? = nil) throws {
+        try initLock.withLock {
+            let isEnabled = !config.isEmpty
+            if approovSDKInitialised && config.isEmpty && !(_approovConfigString?.isEmpty ?? true) {
+                if loggingLevel >= .info {
+                    os_log("ApproovService already initialized with a valid config; ignoring empty configuration", type: .info)
+                }
+                return
+            }
+
+            if isEnabled {
+                do {
+                    try Approov.initialize(config, updateConfig: "auto", comment: comment)
+                    if loggingLevel >= .info {
+                        os_log("ApproovService: Approov SDK initialized", type: .info)
+                    }
+                } catch {
+                    let nsError = error as NSError
+                    if nsError.code == 0, nsError.domain == "Foundation._GenericObjCError" {
+                        if loggingLevel >= .info {
+                            os_log("ApproovService: Approov SDK already initialized", type: .info)
+                        }
+                    } else {
+                        throw ApproovError.initializationFailure(message: "Error initializing Approov SDK: \(nsError.localizedDescription)")
+                    }
+                }
+            }
+
+            // SDK succeeded (or bypass) — now reset and commit new service-layer state.
+            approovSDKInitialised = false
+            _approovConfigString = config
+
+            stateLock.withLock {
+                _proceedOnNetworkFail = false
+                _bindHeader = ""
+                _approovTokenHeader = "Approov-Token"
+                _approovTokenPrefix = ""
+                _approovTraceIDHeader = "Approov-TraceID"
+                _serviceMutator = ApproovServiceMutatorDefault.shared
+                substitutionHeaders = Dictionary()
+                substitutionQueryParams = Set()
+                exclusionURLRegexs = Dictionary()
+                _useApproovStatusIfNoToken = false
+            }
+
+            failureCacheLock.withLock {
+                cachedFailureResult = nil
+                cachedFailureTime = nil
+            }
+
+            approovSDKInitialised = true
+            if isEnabled {
+                Approov.setUserProperty("approov-service-asynchttpclient")
+            }
+            TLSConfiguration.setVerifyPinningBlock(newValue: ApproovPinningVerifier.verifyPinning)
+        }
+    }
+
+    /**
+     * Resets the ApproovService state for testing.
+     */
+    static func resetForTesting() {
+        initLock.withLock {
+            approovSDKInitialised = false
+            _approovConfigString = nil
+        }
+        stateLock.withLock {
+            _proceedOnNetworkFail = false
+            _bindHeader = ""
+            _approovTokenHeader = "Approov-Token"
+            _approovTokenPrefix = ""
+            _approovTraceIDHeader = "Approov-TraceID"
+            _serviceMutator = ApproovServiceMutatorDefault.shared
+            substitutionHeaders = Dictionary()
+            substitutionQueryParams = Set()
+            exclusionURLRegexs = Dictionary()
+            _useApproovStatusIfNoToken = false
+        }
+        failureCacheLock.withLock {
+            cachedFailureResult = nil
+            cachedFailureTime = nil
+        }
+    }
+
+    /**
+     * Indicates whether the service layer has been initialized.
+     */
+    public static func isInitialized() -> Bool {
+        initLock.withLock {
+            approovSDKInitialised
+        }
+    }
+
+    private static var isApproovEnabledInternal: Bool {
+        approovSDKInitialised && !(_approovConfigString?.isEmpty ?? true)
+    }
+
+    /**
+     * Indicates whether Approov protection is enabled for this service layer instance.
+     */
+    public static func isApproovEnabled() -> Bool {
+        initLock.withLock {
+            isApproovEnabledInternal
+        }
+    }
+
+    /**
+     * Sets a flag indicating if the network interceptor should proceed anyway if it is
+     * not possible to obtain an Approov token due to a networking failure.
+     */
+    @available(*, deprecated, message: "No longer used internally. Use setServiceMutator to customize network failure behavior.")
+    public static var proceedOnNetworkFail: Bool {
+        get {
+            stateLock.withLock { _proceedOnNetworkFail }
+        }
+        set {
+            stateLock.withLock { _proceedOnNetworkFail = newValue }
+        }
+    }
+
+    /**
+     * Sets a binding header that must be present on all requests using the Approov service.
+     */
+    public static var bindHeader: String {
+        get {
+            stateLock.withLock { _bindHeader }
+        }
+        set {
+            stateLock.withLock { _bindHeader = newValue }
+        }
+    }
+
+    /**
+     * Sets the header that the Approov token is added on, as well as an optional prefix String.
      */
     public static var approovTokenHeaderAndPrefix: (approovTokenHeader: String, approovTokenPrefix: String) {
         get {
-            var approovTokenHeader = ""
-            var approovTokenPrefix = ""
-            stateLock.withLock {
-                approovTokenHeader = _approovTokenHeader
-                approovTokenPrefix = _approovTokenPrefix
-            }
-            return (approovTokenHeader, approovTokenPrefix)
+            stateLock.withLock { (_approovTokenHeader, _approovTokenPrefix) }
         }
         set {
             stateLock.withLock {
-                (_approovTokenHeader,_approovTokenPrefix) = newValue
+                _approovTokenHeader = newValue.approovTokenHeader
+                _approovTokenPrefix = newValue.approovTokenPrefix
             }
         }
     }
 
-    /** Initialization configuration string. NOTE this must only ever be written to ONCE since Approov SDK can only
-     * be initialized once */
-    private static var _approovConfigString: String?
+    public static func getApproovTokenHeader() -> String {
+        stateLock.withLock { _approovTokenHeader }
+    }
 
-    // Public setter/getter for configuration
-    static var approovConfigString: String? {
-        set (newValue) {
-            stateLock.withLock {
-                if (_approovConfigString == nil) {
-                    _approovConfigString = newValue
-                }
-            }
+    public static func setApproovTraceIDHeader(header: String?) {
+        stateLock.withLock {
+            _approovTraceIDHeader = header
         }
-        get {
-            stateLock.withLock {
-                return _approovConfigString
-            }
+    }
+
+    public static func getApproovTraceIDHeader() -> String? {
+        stateLock.withLock { _approovTraceIDHeader }
+    }
+
+    public static func setUseApproovStatusIfNoToken(shouldUse: Bool) {
+        stateLock.withLock {
+            _useApproovStatusIfNoToken = shouldUse
         }
+    }
+
+    public static func getUseApproovStatusIfNoToken() -> Bool {
+        stateLock.withLock { _useApproovStatusIfNoToken }
+    }
+
+    public static func setServiceMutator(_ mutator: ApproovServiceMutator?) {
+        stateLock.withLock {
+            _serviceMutator = mutator ?? ApproovServiceMutatorDefault.shared
+        }
+    }
+
+    public static func getServiceMutator() -> ApproovServiceMutator {
+        stateLock.withLock { _serviceMutator }
+    }
+
+    public static var approovConfigString: String? {
+        initLock.withLock { _approovConfigString }
     }
 
     /**
-     * Sets a development key indicating that the app is a development version and it should
-     * pass attestation even if the app is not registered or it is running on an emulator. The
-     * development key value can be rotated at any point in the account if a version of the app
-     * containing the development key is accidentally released. This is primarily
-     * used for situations where the app package must be modified or resigned in
-     * some way as part of the testing process.
-     *
-     * @param devKey is the development key to be used
+     * Sets a development key.
      */
     public static func setDevKey(devKey: String) {
-        Approov.setDevKey(devKey)
-        os_log("ApproovService: setDevKey", type: .debug)
-    }
-
-    /**
-     * Allows token prefetch operation to be performed as early as possible. This permits a token to be available while
-     * an application might be loading resources or is awaiting user input. Since the initial token fetch is the most
-     * expensive the prefetch can hide the most latency.
-     */
-    public static func prefetch() {
-        initLock.withLock {
-            if approovSDKInitialised {
-                // We succeeded initializing Approov SDK, fetch a token
-                Approov.fetchToken({(approovResult: ApproovTokenFetchResult) in
-                    // Prefetch done, no need to process response
-                }, "approov.io")
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: setDevKey: SDK not initialized", type: .error)
             }
+            return
+        }
+        Approov.setDevKey(devKey)
+        if loggingLevel >= .debug {
+            os_log("ApproovService: setDevKey", type: .debug)
         }
     }
 
     /**
-     * Adds an Approov token and substitutes header values as defined in substitutionHeaders in the headers if present.
-     * If no token is added and no substitution is made then the original collection of headers are returned, otherwise
-     * a new one is constructed with the updated headers values.
-     * Also substitutes the query parameters defined in substitutionQueryParams in the URL if present. If no
-     * substitution is made then the original URL is returned, otherwise a new one is constructed with the revised query
-     * parameter values.
-     * If it is not currently possible to fetch a token or secure strings due to networking issues then
-     * ApproovError.networkingError is thrown and a user initiated retry of the operation should be allowed.
-     * ApproovError.rejectionError may be thrown if the attestation fails and secure strings cannot be obtained. Other
-     * ApproovErrors represent a more permanent error condition.
-     *
-     * Note this is a blocking function and must not be called from the UI thread!
-     *
-     * @param headers is the collection of headers to be updated
-     * @return URL passed in, or modified with a new URL if required
-     * @return headers passed in, or modified by adding an Approov token header and new header values if required
-     * @throws ApproovError if it is not possible to obtain secure strings for substitution
+     * Allows token prefetch operation to be performed as early as possible.
+     */
+    @available(*, deprecated, message: "Prefetch is managed automatically by the underlying SDK.")
+    public static func prefetch() {
+        if loggingLevel >= .warning {
+            os_log("ApproovService: prefetch is no longer used and does nothing.")
+        }
+    }
+
+    /**
+     * Legacy backward-compatible updateRequest method.
      */
     public static func updateRequest(url: URL, headers: HTTPHeaders) throws -> (URL, HTTPHeaders) {
-        var exclusionURLRegexs: Dictionary<String, NSRegularExpression> = [:]
-        stateLock.withLock {
-            exclusionURLRegexs = ApproovService.exclusionURLRegexs
+        let appReq = ApproovRequest(url: url, method: "GET", headers: headers, body: nil)
+        let response = updateRequestWithApproov(request: appReq)
+        if let error = response.error {
+            throw error
         }
-        // Check if the URL matches one of the exclusion regexs and just return original headers if so
-        for (_, regex) in exclusionURLRegexs {
-            let urlString = url.absoluteString
-            let urlStringRange = NSRange(urlString.startIndex..<urlString.endIndex, in: urlString)
-            let matches: [NSTextCheckingResult] = regex.matches(in: urlString, options: [], range: urlStringRange)
-            if !matches.isEmpty {
-                return (url, headers);
-            }
+        switch response.decision {
+        case .ShouldProceed, .ShouldIgnore:
+            return (response.request.url, response.request.headers)
+        case .ShouldRetry:
+            throw ApproovError.networkingError(message: "Token fetch for \(url.host ?? ""): \(response.sdkMessage)")
+        case .ShouldFail:
+            throw ApproovError.permanentError(message: "Token fetch for \(url.host ?? ""): \(response.sdkMessage)")
         }
-        var updatedURL = url
-        var updatedHeaders = headers
-        if let hostname = url.host {
-            updatedHeaders = try updateRequestHeaders(headers: headers, hostname: hostname)
-            updatedURL = try substituteQueryParams(url: url)
-        }
-        return (updatedURL, updatedHeaders)
     }
 
-    /**
-     * Adds an Approov token and substitutes header values as defined in substitutionHeaders in the headers if present.
-     * If no token is added and no substitution is made then the original collection of headers are returned, otherwise
-     * a new one is constructed with the updated headers values. If it is not currently possible to fetch a token or
-     * secure strings due to networking issues then ApproovError.networkingError is thrown and a user initiated retry of
-     * the operation should be allowed. ApproovError.rejectionError may be thrown if the attestation fails and secure
-     * strings cannot be obtained. Other ApproovErrors represent a more permanent error condition.
-     *
-     * Note this is a blocking function and must not be called from the UI thread!
-     *
-     * @param headers is the collection of headers to be updated
-     * @return headers passed in, or modified by adding an Approov token header and new header values if required
-     * @throws ApproovError if it is not possible to obtain secure strings for substitution
-     */
-    static func updateRequestHeaders(headers: HTTPHeaders, hostname: String) throws -> HTTPHeaders {
-        // Check if Bind Header is set to a non empty string
-        if ApproovService.bindHeader != "" {
-            if let aValue = headers.first(name: ApproovService.bindHeader) {
-                // Add the Bind Header as a data hash to Approov token
-                Approov.setDataHashInToken(aValue)
+    public static func signRequest(_ request: HTTPClient.Request) throws -> HTTPClient.Request {
+        let bodyData = try getHTTPBody(request)
+        let approovReq = ApproovRequest(
+            url: request.url,
+            method: request.method.rawValue,
+            headers: request.headers,
+            body: bodyData
+        )
+        let response = updateRequestWithApproov(request: approovReq)
+        if let error = response.error {
+            throw error
+        }
+        switch response.decision {
+        case .ShouldProceed, .ShouldIgnore:
+            return try HTTPClient.Request(
+                url: response.request.url,
+                method: request.method,
+                headers: response.request.headers,
+                body: request.body,
+                tlsConfiguration: request.tlsConfiguration
+            )
+        case .ShouldRetry:
+            throw ApproovError.networkingError(message: "Token fetch for \(request.url.host ?? ""): \(response.sdkMessage)")
+        case .ShouldFail:
+            throw ApproovError.permanentError(message: "Token fetch for \(request.url.host ?? ""): \(response.sdkMessage)")
+        }
+    }
+    
+    private static func getHTTPBody(_ request: HTTPClient.Request) throws -> Data? {
+        guard let requestBody = request.body else {
+            return nil
+        }
+        
+        var collectedData: Data? = nil
+        let eventLoop = EmbeddedEventLoop()
+        let writer = HTTPClient.Body.StreamWriter { ioData in
+            switch ioData {
+            case .byteBuffer(let buffer):
+                collectedData = buffer.getData(at: 0, length: buffer.readableBytes)
+            default:
+                break
             }
+            return eventLoop.makeSucceededFuture(())
         }
-
-        // Fetch the Approov token
-        let result: ApproovTokenFetchResult = Approov.fetchTokenAndWait(hostname)
-        os_log("ApproovService: update headers %@: %@", type: .info, hostname, result.loggableToken())
-
-        // Log if a configuration update is received and call fetchConfig to clear the update state
-        if result.isConfigChanged {
-            Approov.fetchConfig()
-            os_log("ApproovService: dynamic configuration update received")
-        }
-
-        // Handle the Approov token fetch response
-        var updatedHeaders: HTTPHeaders = [:]
-        switch result.status {
-        case .success:
-            // Can go ahead and make the API call with the provided request object
-            // Set Approov-Token header
-            updatedHeaders.add(name: ApproovService.approovTokenHeaderAndPrefix.approovTokenHeader,
-                value: ApproovService.approovTokenHeaderAndPrefix.approovTokenPrefix + result.token)
-            break
-        case .noNetwork,
-             .poorNetwork,
-             .mitmDetected:
-            // We are unable to get an Approov token due to network conditions so - unless this is overridden - we must
-            // not proceed with the network request. The request can be retried by the user later.
-            if !proceedOnNetworkFail {
-                throw ApproovError.networkingError(message: "Token fetch for " + hostname + ": " +
-                    Approov.string(from: result.status))
-            }
-        case .unprotectedURL,
-             .unknownURL,
-             .noApproovService:
-            // We do NOT add the Approov-Token header to the request headers and proceed
-            break
-        default:
-            // We have failed to get an Approov token with a more serious permanent error
-            throw ApproovError.permanentError(message: "Token fetch for " + hostname + ": " +
-                Approov.string(from: result.status))
-        }
-
-        // We only continue additional processing if we had a valid status from Approov, to prevent additional delays
-        // by trying to fetch from Approov again and this also protects against header substitutions in domains not
-        // protected by Approov and therefore are potentially subject to a MitM.
-        if (result.status != .success) && (result.status != .unprotectedURL) {
-            return updatedHeaders;
-        }
-
-        // Deal with any header substitutions, which may require further fetches but these should be using cached
-        // results
-        for headerIndex in headers.indices {
-            let headerName = headers[headerIndex].name
-            var headerValue = headers[headerIndex].value
-            // Check whether header is eligible for substitution
-            var substHeaderValuePrefix: String?
-            stateLock.withLock {
-                substHeaderValuePrefix = substitutionHeaders[headerName]
-            }
-            if substHeaderValuePrefix != nil {
-                // We need to check whether there is a substitution available in Approov
-                // Remove prefix from header value before lookup
-                if (substHeaderValuePrefix!.count > 0 && headerValue.hasPrefix(substHeaderValuePrefix!)) {
-                    headerValue.removeFirst(substHeaderValuePrefix!.count)
-                }
-                // Look up header value in Approov
-                let approovResults = Approov.fetchSecureStringAndWait(String(headerValue), nil)
-                os_log("ApproovService: Substituting header: %@, %@", type: .info, headerName,
-                    Approov.string(from: approovResults.status))
-                // Process the result of the secure string fetch operation
-                switch approovResults.status {
-                case .success:
-                    // Add the modified header to the updated headers
-                    if let secureStringResult = approovResults.secureString {
-                        updatedHeaders.add(name: headerName,
-                                           value: substHeaderValuePrefix! + secureStringResult)
-                    } else {
-                        // Secure string is nil
-                        throw ApproovError.permanentError(message: "Header substitution: key lookup error")
-                    }
-                case .rejected:
-                    // If the request is rejected then we provide a special exception with additional information
-                    throw ApproovError.rejectionError(message: "Header substitution: rejected",
-                        ARC: approovResults.arc, rejectionReasons: approovResults.rejectionReasons)
-                case .noNetwork,
-                     .poorNetwork,
-                     .mitmDetected:
-                    // We are unable to get the secure string due to network conditions, so - unless this is overridden
-                    // - we must not proceed. The request can be retried by the user later.
-                    if !proceedOnNetworkFail {
-                        throw ApproovError.networkingError(message: "Header substitution: network issue, retry needed")
-                    }
-                case .unknownKey:
-                    // We have failed to get a secure string with a more serious permanent error
-                    throw ApproovError.permanentError(message: "Header substitution: " +
-                        Approov.string(from: approovResults.status))
-                default:
-                    // Add the original header to the updated headers
-                    updatedHeaders.add(name: headerName, value: substHeaderValuePrefix! + headerValue)
-                }
-            } else {
-                // No substitution defined, copy original header
-                updatedHeaders.add(name: headerName, value: headerValue)
-            }
-        }
-        return updatedHeaders
+        
+        _ = requestBody.stream(writer)
+        return collectedData
     }
 
-    /**
-     * Adds the value of a header which should be subject to secure strings substitution. This
-     * means that if the header is present then the value will be used as a key to look up a
-     * secure string value which will be substituted into the header value instead. This allows
-     * easy migration to the use of secure strings. A required prefix may be specified to deal
-     * with cases such as the use of "Bearer " prefixed before values in an authorization header.
-     *
-     * @param header is the header to be marked for substitution
-     * @param prefix is any required prefix to the value being substituted or nil if not required
-     */
-    public static func addSubstitutionHeader(header: String, prefix: String?) {
-        if prefix == nil {
-            stateLock.withLock {
-                ApproovService.substitutionHeaders[header] = ""
+    private static func applyMutatorError(_ error: Error,
+                                          response: inout ApproovUpdateResponse,
+                                          context: String) {
+        if let approovError = error as? ApproovError {
+            response.error = approovError
+            switch approovError {
+            case .networkingError:
+                response.decision = .ShouldRetry
+            default:
+                response.decision = .ShouldFail
             }
         } else {
-            stateLock.withLock {
-                ApproovService.substitutionHeaders[header] = prefix
+            response.error = ApproovError.permanentError(message: "\(context): \(error.localizedDescription)")
+            response.decision = .ShouldFail
+        }
+    }
+
+    private static func getCachedFailure() -> ApproovTokenFetchResult? {
+        return failureCacheLock.withLock {
+            return getCachedFailureLocked()
+        }
+    }
+
+    private static func getCachedFailureLocked() -> ApproovTokenFetchResult? {
+        guard let result = cachedFailureResult,
+              let time = cachedFailureTime else {
+            return nil
+        }
+        if (ProcessInfo.processInfo.systemUptime - time) < failureCacheTTL {
+            os_log("ApproovService: using cached failure: %@", type: .debug, Approov.string(from: result.status))
+            return result
+        }
+        cachedFailureResult = nil
+        cachedFailureTime = nil
+        return nil
+    }
+
+    private static func fetchTokenWithFailureCache(url: String) -> ApproovTokenFetchResult {
+        var missGroupToWaitFor: DispatchGroup?
+        var ownedMissGroup: DispatchGroup?
+
+        if let cachedResult = failureCacheLock.withLock({ () -> ApproovTokenFetchResult? in
+            if let result = getCachedFailureLocked() {
+                return result
+            }
+            if let missGroup = failureCacheMissGroup {
+                missGroupToWaitFor = missGroup
+            } else {
+                let missGroup = DispatchGroup()
+                missGroup.enter()
+                failureCacheMissGroup = missGroup
+                ownedMissGroup = missGroup
+            }
+            return nil
+        }) {
+            return cachedResult
+        }
+
+        if let missGroupToWaitFor {
+            missGroupToWaitFor.wait()
+            if let cachedResult = getCachedFailure() {
+                return cachedResult
+            }
+            let result = Approov.fetchTokenAndWait(url)
+            cacheFailureIfNeeded(result)
+            return result
+        }
+
+        let result = Approov.fetchTokenAndWait(url)
+        failureCacheLock.withLock {
+            cacheFailureIfNeededLocked(result)
+            failureCacheMissGroup = nil
+            ownedMissGroup?.leave()
+        }
+        return result
+    }
+
+    private static func cacheFailureIfNeededLocked(_ result: ApproovTokenFetchResult) {
+        let status = result.status
+        switch status {
+        case .noNetwork, .poorNetwork, .mitmDetected, .noApproovService:
+            cachedFailureResult = result
+            cachedFailureTime = ProcessInfo.processInfo.systemUptime
+            os_log("ApproovService: caching failure: %@", type: .debug, Approov.string(from: status))
+        default:
+            break
+        }
+    }
+
+    private static func cacheFailureIfNeeded(_ result: ApproovTokenFetchResult) {
+        failureCacheLock.withLock {
+            cacheFailureIfNeededLocked(result)
+        }
+    }
+
+    public static func setFailureCacheTTL(ttl: TimeInterval) {
+        failureCacheLock.withLock {
+            failureCacheTTL = ttl
+        }
+    }
+
+    /**
+     * Modern mutator-integrated updateRequestWithApproov method.
+     */
+    public static func updateRequestWithApproov(request: ApproovRequest) -> ApproovUpdateResponse {
+        let url = request.url
+        var changes = ApproovRequestMutations()
+
+        if !isApproovEnabled() {
+            if loggingLevel >= .info {
+                os_log("ApproovService: Approov unavailable, forwarding: %@", type: .info, url.absoluteString)
+            }
+            return ApproovUpdateResponse(request: request, decision: .ShouldIgnore, sdkMessage: "", error: nil)
+        }
+
+        let mutator = getServiceMutator()
+        do {
+            if try !mutator.handleInterceptorShouldProcessRequest(request) {
+                if loggingLevel >= .info {
+                    os_log("ApproovService: excluded, forwarding: %@", type: .info, url.absoluteString)
+                }
+                return ApproovUpdateResponse(request: request, decision: .ShouldIgnore, sdkMessage: "", error: nil)
+            }
+        } catch {
+            var response = ApproovUpdateResponse(request: request, decision: .ShouldFail, sdkMessage: "", error: nil)
+            applyMutatorError(error, response: &response, context: "Interceptor should process request")
+            return response
+        }
+
+        // we construct a response to return
+        var response = ApproovUpdateResponse(request: request, decision: .ShouldFail, sdkMessage: "", error: nil)
+
+        // get all of the headers
+        let allHeaders = request.headers
+
+        // check if Bind Header is set to a non empty String
+        let bindHeader = stateLock.withLock {
+            return _bindHeader
+        }
+        if bindHeader != "" {
+            if let value = allHeaders.first(name: bindHeader) {
+                Approov.setDataHashInToken(value)
+            }
+        }
+
+        // Fetch an Approov token
+        let approovResult = fetchTokenWithFailureCache(url: url.absoluteString)
+        let hostname = url.host ?? ""
+        if loggingLevel >= .info {
+            os_log("ApproovService: updateRequest %@: %@", type: .info, hostname, approovResult.loggableToken())
+        }
+        if approovResult.isConfigChanged {
+            Approov.fetchConfig()
+            if loggingLevel >= .info {
+                os_log("ApproovService: dynamic configuration update received")
+            }
+        }
+
+        response.sdkMessage = Approov.string(from: approovResult.status)
+
+        var hasChanges = false
+        var setTokenHeaderKey: String?
+        var setTokenHeaderValue: String?
+        var setTraceIDHeaderKey: String?
+        var setTraceIDHeaderValue: String?
+
+        do {
+            let shouldAddToken = try mutator.handleInterceptorFetchTokenResult(approovResult, url: url.absoluteString)
+            response.decision = .ShouldProceed
+            if !shouldAddToken {
+                return response
+            }
+        } catch {
+            applyMutatorError(error, response: &response, context: "Approov token fetch")
+            return response
+        }
+
+        let tokenHeader = stateLock.withLock {
+            return _approovTokenHeader
+        }
+        let tokenPrefix = stateLock.withLock {
+            return _approovTokenPrefix
+        }
+        hasChanges = true
+        setTokenHeaderKey = tokenHeader
+        if approovResult.token.isEmpty && (stateLock.withLock { _useApproovStatusIfNoToken }) {
+            setTokenHeaderValue = tokenPrefix + response.sdkMessage
+        } else {
+            setTokenHeaderValue = tokenPrefix + approovResult.token
+        }
+        let traceID = approovResult.traceID
+        if let traceHeader = stateLock.withLock({ _approovTraceIDHeader }),
+           !traceHeader.isEmpty,
+           !traceID.isEmpty {
+            hasChanges = true
+            setTraceIDHeaderKey = traceHeader
+            setTraceIDHeaderValue = traceID
+        }
+
+        // deal with header substitutions
+        var setSubstitutionHeaders: [String: String] = [:]
+        let subsHeadersCopy = getSubstitutionHeaders()
+        for (header, prefix) in subsHeadersCopy {
+            if let value = allHeaders.first(name: header) {
+                if ((value.hasPrefix(prefix)) && (value.count > prefix.count)) {
+                    let index = prefix.index(prefix.startIndex, offsetBy: prefix.count)
+                    let approovResults = Approov.fetchSecureStringAndWait(String(value.suffix(from:index)), nil)
+                    if loggingLevel >= .info {
+                        os_log("ApproovService: Substituting header: %@, %@", type: .info, header, Approov.string(from: approovResults.status))
+                    }
+
+                    do {
+                        if try mutator.handleInterceptorHeaderSubstitutionResult(approovResults, header: header) {
+                            if let secureStringResult = approovResults.secureString {
+                                hasChanges = true
+                                setSubstitutionHeaders[header] = prefix + secureStringResult
+                            } else {
+                                response.decision = .ShouldFail
+                                response.error = ApproovError.permanentError(message: "Header substitution: key lookup error")
+                                return response
+                            }
+                        }
+                    } catch {
+                        applyMutatorError(error, response: &response, context: "Header substitution for \(header)")
+                        return response
+                    }
+                }
+            }
+        }
+
+        // deal with query parameter substitutions
+        var updateURL: URL?
+        var queryKeys: [String] = []
+        let subsQueryParamsCopy = getSubstitutionQueryParams()
+        var updateURLString = url.absoluteString
+        for entry in subsQueryParamsCopy {
+            let urlStringRange = NSRange(updateURLString.startIndex..<updateURLString.endIndex, in: updateURLString)
+            let regex = try! NSRegularExpression(pattern: #"[\\?&]"# + entry + #"=([^&;]+)"#, options: [])
+            let matches: [NSTextCheckingResult] = regex.matches(in: updateURLString, options: [], range: urlStringRange)
+            for match: NSTextCheckingResult in matches {
+                for rangeIndex in 1..<match.numberOfRanges {
+                    let matchRange = match.range(at: rangeIndex)
+                    if let substringRange = Range(matchRange, in: updateURLString) {
+                        let queryValue = String(updateURLString[substringRange])
+                        let approovResults = Approov.fetchSecureStringAndWait(String(queryValue), nil)
+                        if loggingLevel >= .info {
+                            os_log("ApproovService: Attempting query parameter substitution: %@, %@", entry,
+                                Approov.string(from: approovResults.status))
+                        }
+
+                        do {
+                            if try mutator.handleInterceptorQueryParamSubstitutionResult(approovResults, queryKey: entry) {
+                                if let secureStringResult = approovResults.secureString {
+                                    hasChanges = true
+                                    queryKeys.append(entry)
+                                    updateURLString.replaceSubrange(Range(matchRange, in: updateURLString)!, with: secureStringResult)
+                                    updateURL = URL(string: updateURLString)
+                                    if updateURL == nil {
+                                        response.decision = .ShouldFail
+                                        response.error = ApproovError.permanentError(
+                                            message: "Query parameter substitution for \(entry): malformed URL \(updateURLString)")
+                                        return response
+                                    }
+                                }
+                            }
+                        } catch {
+                            applyMutatorError(error, response: &response, context: "Query parameter substitution for \(entry)")
+                            return response
+                        }
+                    }
+                }
+            }
+        }
+
+        // apply all the changes to the request
+        if (hasChanges) {
+            if let tokenHeaderKey = setTokenHeaderKey,
+               let tokenHeaderValue = setTokenHeaderValue {
+                response.request.headers.replaceOrAdd(name: tokenHeaderKey, value: tokenHeaderValue)
+                changes.setTokenHeaderKey(tokenHeaderKey)
+            }
+            if let traceIDHeaderKey = setTraceIDHeaderKey,
+               let traceIDHeaderValue = setTraceIDHeaderValue {
+                response.request.headers.replaceOrAdd(name: traceIDHeaderKey, value: traceIDHeaderValue)
+                changes.setTraceIDHeaderKey(traceIDHeaderKey)
+            }
+            if (!setSubstitutionHeaders.isEmpty) {
+                for (header, value) in setSubstitutionHeaders {
+                    response.request.headers.replaceOrAdd(name: header, value: value)
+                }
+                changes.setSubstitutionHeaderKeys(Array(setSubstitutionHeaders.keys))
+            }
+            if let updateURLString = updateURL,
+               let originalURLString = request.url.absoluteString as String? {
+                if (originalURLString != updateURLString.absoluteString) {
+                    response.request.url = updateURLString
+                    changes.setSubstitutionQueryParamResults(originalURL: originalURLString, substitutionQueryParamKeys: queryKeys)
+                }
+            }
+        }
+
+        // call the processed request callback
+        do {
+            response.request = try mutator.handleInterceptorProcessedRequest(response.request, changes: changes)
+        } catch {
+            applyMutatorError(error, response: &response, context: "Interceptor processed request")
+            return response
+        }
+
+        return response
+    }
+
+    /**
+     * Adds the value of a header which should be subject to secure strings substitution.
+     */
+    public static func addSubstitutionHeader(header: String, prefix: String?) {
+        stateLock.withLock {
+            substitutionHeaders[header] = prefix ?? ""
+            if _loggingLevel >= .debug {
+                os_log("ApproovService: addSubstitutionHeader: %@ %@", type: .debug, header, prefix ?? "")
             }
         }
     }
@@ -462,427 +759,275 @@ public class ApproovService {
      */
     public static func removeSubstitutionHeader(header: String) {
         stateLock.withLock {
-            if ApproovService.substitutionHeaders[header] != nil {
-                ApproovService.substitutionHeaders.removeValue(forKey: header)
+            if substitutionHeaders[header] != nil {
+                substitutionHeaders.removeValue(forKey: header)
+            }
+            if _loggingLevel >= .debug {
+                os_log("ApproovService: removeSubstitutionHeader: %@", type: .debug, header)
             }
         }
     }
 
-    /**
-     * Substitutes the query parameters defined in substitutionQueryParams in the URL if present. If no substitution is
-     * made then the original URL is returned, otherwise a new one is constructed with the revised query
-     * parameter values. If it is not currently possible to fetch secure strings token due to
-     * networking issues then ApproovError.networkingError is thrown and a user initiated retry of the
-     * operation should be allowed. ApproovError.rejectionError may be thrown if the attestation
-     * fails and secure strings cannot be obtained. Other ApproovErrors represent a more
-     * permanent error condition.
-     *
-     * Note this is a blocking function and must not be called from the UI thread!
-     *
-     * @param url is the URL being analyzed for substitution
-     * @return URL passed in, or modified with a new URL if required
-     * @throws ApproovError if it is not possible to obtain secure strings for substitution
-     */
-    static func substituteQueryParams(url: URL) throws -> URL {
-        var updatedURL = url
-        var substitutionQueryParams: Set<String> = []
-        stateLock.withLock {
-            substitutionQueryParams = ApproovService.substitutionQueryParams
-        }
-        for queryParam in substitutionQueryParams {
-            updatedURL = try substituteQueryParam(url: updatedURL, queryParameter: queryParam)
-        }
-        return updatedURL
-    }
-
-    /**
-     * Substitutes the given query parameter in the URL. If no substitution is made then the
-     * original URL is returned, otherwise a new one is constructed with the revised query
-     * parameter value. If it is not currently possible to fetch secure strings token due to
-     * networking issues then ApproovError.networkingError is thrown and a user initiated retry of the
-     * operation should be allowed. ApproovError.rejectionError may be thrown if the attestation
-     * fails and secure strings cannot be obtained. Other ApproovErrors represent a more
-     * permanent error condition.
-     *
-     * @param url is the URL being analyzed for substitution
-     * @param queryParameter is the parameter to be potentially substituted
-     * @return URL passed in, or modified with a new URL if required
-     * @throws ApproovError if it is not possible to obtain secure strings for substitution
-     */
-    public static func substituteQueryParam(url: URL, queryParameter: String) throws -> URL {
-        var urlString = url.absoluteString
-        let urlStringRange = NSRange(urlString.startIndex..<urlString.endIndex, in: urlString)
-        let regex = try! NSRegularExpression(pattern: #"[\\?&]"# + queryParameter + #"=([^&;]+)"#, options: [])
-        let matches: [NSTextCheckingResult] = regex.matches(in: urlString, options: [], range: urlStringRange)
-        for match: NSTextCheckingResult in matches {
-            // We skip the range at index 0 as this is the match (e.g. ?Api-Key=api_key_placeholder) for the whole
-            // regex, but we only want to replace the query parameter value part (e.g. api_key_placeholder)
-            for rangeIndex in 1..<match.numberOfRanges {
-                // We have found an occurrence of the query parameter to be replaced so we look up the existing
-                // value as a key for a secure string
-                let matchRange = match.range(at: rangeIndex)
-                if let substringRange = Range(matchRange, in: urlString) {
-                    let queryValue = String(urlString[substringRange])
-                    let approovResults = Approov.fetchSecureStringAndWait(String(queryValue), nil)
-                    os_log("ApproovService: Substituting query parameter: %@, %@", queryParameter,
-                        Approov.string(from: approovResults.status));
-                    // Process the result of the secure string fetch operation
-                    switch approovResults.status {
-                    case .success:
-                        // perform a query substitution
-                        if let secureStringResult = approovResults.secureString {
-                            urlString.replaceSubrange(Range(matchRange, in: urlString)!, with: secureStringResult)
-                            if let newURL = URL(string: urlString) {
-                                return newURL
-                            } else {
-                                throw ApproovError.runtimeError(
-                                    message: "Query parameter substitution for \(queryParameter): malformed URL \(urlString)")
-                            }
-                        }
-                    case .rejected:
-                        // If the request is rejected then we provide a special exception with additional information
-                        throw ApproovError.rejectionError(
-                            message: "Query parameter substitution for \(queryParameter): rejected",
-                            ARC: approovResults.arc,
-                            rejectionReasons: approovResults.rejectionReasons
-                        )
-                    case .noNetwork,
-                         .poorNetwork,
-                         .mitmDetected:
-                        // We are unable to get the secure string due to network conditions so the request can
-                        // be retried by the user later
-                        // We are unable to get the secure string due to network conditions, so - unless this is
-                        // overridden - we must not proceed. The request can be retried by the user later.
-                        if !proceedOnNetworkFail {
-                            throw ApproovError.networkingError(message: "Query parameter substitution for " +
-                                "\(queryParameter): network issue, retry needed")
-                        }
-                    case .unknownKey:
-                        // Do not modify the URL
-                        break
-                    default:
-                        // We have failed to get a secure string with a more serious permanent error
-                        throw ApproovError.permanentError(
-                            message: "Query parameter substitution for \(queryParameter): " +
-                            Approov.string(from: approovResults.status)
-                        )
-                    }
-                }
-            }
-        }
-        // Return the original URL
-        return url
+    public static func getSubstitutionHeaders() -> Dictionary<String, String> {
+        stateLock.withLock { substitutionHeaders }
     }
 
     /**
      * Adds a key name for a query parameter that should be subject to secure strings substitution.
-     * This means that if the query parameter is present in a URL then the value will be used as a
-     * key to look up a secure string value which will be substituted as the query parameter value
-     * instead. This allows easy migration to the use of secure strings.
-     *
-     * @param key is the query parameter key name to be added for substitution
      */
     public static func addSubstitutionQueryParam(key: String) {
         stateLock.withLock {
-            _ = substitutionQueryParams.insert(key);
+            substitutionQueryParams.insert(key)
+            if _loggingLevel >= .debug {
+                os_log("ApproovService: addSubstitutionQueryParam: %@", type: .debug, key)
+            }
         }
     }
 
     /**
      * Removes a query parameter key name previously added using addSubstitutionQueryParam.
-     *
-     * @param key is the query parameter key name to be removed for substitution
      */
     public static func removeSubstitutionQueryParam(key: String) {
         stateLock.withLock {
-            _ = substitutionQueryParams.remove(key);
+            substitutionQueryParams.remove(key)
+            if _loggingLevel >= .debug {
+                os_log("ApproovService: removeSubstitutionQueryParam: %@", type: .debug, key)
+            }
         }
     }
 
+    public static func getSubstitutionQueryParams() -> Set<String> {
+        stateLock.withLock { substitutionQueryParams }
+    }
+
     /**
-     * Adds an exclusion URL regular expression. If a URL for a request matches this regular expression
-     * then it will not be subject to any Approov protection. Note that this facility must be used with
-     * EXTREME CAUTION due to the impact of dynamic pinning. Pinning may be applied to all domains added
-     * using Approov, and updates to the pins are received when an Approov fetch is performed. If you
-     * exclude some URLs on domains that are protected with Approov, then these will be protected with
-     * Approov pins but without a path to update the pins until a URL is used that is not excluded. Thus
-     * you are responsible for ensuring that there is always a possibility of calling a non-excluded
-     * URL, or you should make an explicit call to fetchToken if there are persistent pinning failures.
-     * Conversely, use of those option may allow a connection to be established before any dynamic pins
-     * have been received via Approov, thus potentially opening the channel to a MitM.
-     *
-     * @param urlRegex is the regular expression that will be compared against URLs to exclude them
+     * Adds an exclusion URL regular expression.
      */
     public static func addExclusionURLRegex(urlRegex: String) {
-        do {
-            let regex = try NSRegularExpression(pattern: urlRegex, options: [])
-            stateLock.withLock {
+        stateLock.withLock {
+            do {
+                let regex = try NSRegularExpression(pattern: urlRegex, options: [])
                 exclusionURLRegexs[urlRegex] = regex
+                if _loggingLevel >= .debug {
+                    os_log("ApproovService: addExclusionURLRegex: %@", type: .debug, urlRegex)
+                }
+            } catch {
+                if _loggingLevel >= .debug {
+                    os_log("ApproovService: addExclusionURLRegex: %@ error: %@", type: .debug, urlRegex, error.localizedDescription)
+                }
             }
-            os_log("ApproovService: addExclusionURLRegex: %@", type: .debug, urlRegex)
-        } catch {
-            os_log("ApproovService: addExclusionURLRegex: %@ error: %@", type: .debug, urlRegex, error.localizedDescription)
         }
     }
 
     /**
-     * Removes an exclusion URL regular expression previously added using addExclusionURLRegex.
-     *
-     * @param urlRegex is the regular expression that will be compared against URLs to exclude them
+     * Removes an exclusion URL regular expression.
      */
     public static func removeExclusionURLRegex(urlRegex: String) {
         stateLock.withLock {
             if exclusionURLRegexs[urlRegex] != nil {
-                os_log("ApproovService: removeExclusionURLRegex: %@", type: .debug, urlRegex)
                 exclusionURLRegexs.removeValue(forKey: urlRegex)
+                if _loggingLevel >= .debug {
+                    os_log("ApproovService: removeExclusionURLRegex: %@", type: .debug, urlRegex)
+                }
             }
         }
     }
 
-    /**
-     * Gets the device ID used by Approov to identify the particular device that the SDK is running on. Note
-     * that different Approov apps on the same device will return a different ID. Moreover, the ID may be
-     * changed by an uninstall and reinstall of the app.
-     *
-     * @return String of the device ID
-     * @throws ApproovError if there was a problem
-     */
-    public static func getDeviceID() throws -> String {
-        if let deviceID: String = Approov.getDeviceID() {
-            os_log("ApproovService: getDeviceID: %@", type: .debug, deviceID)
-            return deviceID
-        }
-        throw ApproovError.runtimeError(message: "getDeviceID: no device ID")
+    public static func getExclusionURLRegexs() -> Dictionary<String, NSRegularExpression> {
+        stateLock.withLock { exclusionURLRegexs }
     }
 
     /**
-     * Directly sets the data hash to be included in subsequently fetched Approov tokens. If the hash is
-     * different from any previously set value then this will cause the next token fetch operation to
-     * fetch a new token with the correct payload data hash. The hash appears in the
-     * 'pay' claim of the Approov token as a base64 encoded string of the SHA256 hash of the
-     * data. Note that the data is hashed locally and never sent to the Approov cloud service.
-     *
-     * @param data is the data to be hashed and set in the token
+     * Gets the device ID used by Approov.
+     */
+    public static func getDeviceID() -> String? {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: getDeviceID: SDK not initialized", type: .error)
+            }
+            return nil
+        }
+        let deviceID = Approov.getDeviceID()
+        if (deviceID != nil) {
+            if loggingLevel >= .debug {
+                os_log("ApproovService: getDeviceID %@", type: .debug, deviceID!)
+            }
+        }
+        return deviceID
+    }
+
+    /**
+     * Directly sets the data hash to be included in subsequently fetched Approov tokens.
      */
     public static func setDataHashInToken(data: String) {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: setDataHashInToken: SDK not initialized", type: .error)
+            }
+            return
+        }
+        if loggingLevel >= .debug {
+            os_log("ApproovService: setDataHashInToken", type: .debug)
+        }
         Approov.setDataHashInToken(data)
-        os_log("ApproovService: setDataHashInToken", type: .debug)
     }
 
     /**
-     * Performs an Approov token fetch for the given URL. This should be used in situations where it
-     * is not possible to use the networking interception to add the token. This will
-     * likely require network access so may take some time to complete. If the attestation fails
-     * for any reason then an ApproovError is thrown. This will be ApproovNetworkException for
-     * networking issues wher a user initiated retry of the operation should be allowed. Note that
-     * the returned token should NEVER be cached by your app, you should call this function when
-     * it is needed.
-     *
-     * @param url is the URL giving the domain for the token fetch
-     * @return String of the fetched token
-     * @throws ApproovError if there was a problem
+     * Performs an Approov token fetch for the given URL.
      */
     public static func fetchToken(url: String) throws -> String {
-        // Fetch the Approov token
-        let result: ApproovTokenFetchResult = Approov.fetchTokenAndWait(url)
-        os_log("ApproovService: fetchToken: %@", type: .debug, Approov.string(from: result.status))
-
-        // Process the status
-        switch result.status {
-        case .success:
-            // Provide the Approov token result
-            return result.token
-        case .noNetwork,
-             .poorNetwork,
-             .mitmDetected:
-            // We are unable to get an Approov token due to network conditions
-            throw ApproovError.networkingError(message: "fetchToken: " + Approov.string(from: result.status))
-        default:
-            // We have failed to get an Approov token due to a more permanent error
-            throw ApproovError.permanentError(message: "fetchToken: " + Approov.string(from: result.status))
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: fetchToken: SDK not initialized", type: .error)
+            }
+            throw ApproovError.permanentError(message: "fetchToken: SDK not initialized")
         }
+        let result = Approov.fetchTokenAndWait(url)
+        if loggingLevel >= .debug {
+            os_log("ApproovService: fetchToken: %@", type: .debug, Approov.string(from: result.status))
+        }
+        try getServiceMutator().handleFetchTokenResult(result)
+        return result.token
     }
 
     /**
-     * Gets the signature for the given message. This uses an account specific message signing key that is
-     * transmitted to the SDK after a successful fetch if the facility is enabled for the account. Note
-     * that if the attestation failed then the signing key provided is actually random so that the
-     * signature will be incorrect. An Approov token should always be included in the message
-     * being signed and sent alongside this signature to prevent replay attacks. If no signature is
-     * available, because there has been no prior fetch or the feature is not enabled, then an
-     * ApproovError is thrown.
-     *
-     * @param message is the message whose content is to be signed
-     * @return String of the base64 encoded message signature
-     * @throws ApproovError if there was a problem
+     * Sets the install attributes to be included in the Approov token.
      */
-    public static func getMessageSignature(message: String) throws -> String {
-        if let signature: String = Approov.getMessageSignature(message) {
-            os_log("ApproovService: getMessageSignature", type: .debug)
-            return signature
+    public static func setInstallAttrsInToken(attrs: String) throws {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: setInstallAttrsInToken: SDK not initialized", type: .error)
+            }
+            throw ApproovError.permanentError(message: "setInstallAttrsInToken: SDK not initialized")
         }
-        throw ApproovError.permanentError(message: "getMessageSignature: no signature available")
+        Approov.setInstallAttrsInToken(attrs)
+        if loggingLevel >= .debug {
+            os_log("ApproovService: setInstallAttrsInToken", type: .debug)
+        }
     }
 
     /**
-     * Fetches a secure string with the given key. If newDef is not nil then a secure string for
-     * the particular app instance may be defined. In this case the new value is returned as the
-     * secure string. Use of an empty string for newDef removes the string entry. Note that this
-     * call may require network transaction and thus may block for some time, so should not be called
-     * from the UI thread. If the attestation fails for any reason then an exception is raised. Note
-     * that the returned string should NEVER be cached by your app, you should call this function when
-     * it is needed. If the fetch fails for any reason an exception is thrown with description. Exceptions
-     * could be due to the feature not being enabled from the CLI tools (ApproovError.configurationError
-     * type raised), a rejection throws an Approov.rejectionError type which might include additional
-     * information regarding the failure reason. An ApproovError.networkingError exception should allow a
-     * retry operation to be performed and finally if some other error occurs an Approov.permanentError
-     * is raised.
-     *
-     * @param key is the secure string key to be looked up
-     * @param newDef is any new definition for the secure string, or nil for lookup only
-     * @return secure string (should not be cached by your app) or nil if it was not defined or an error ocurred
-     * @throws exception with description of cause
+     * Gets the account message signature.
+     */
+    public static func getAccountMessageSignature(message: String) -> String? {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: getAccountMessageSignature: SDK not initialized", type: .error)
+            }
+            return nil
+        }
+        return Approov.getMessageSignature(message)
+    }
+
+    /**
+     * Gets the install message signature.
+     */
+    public static func getInstallMessageSignature(message: String) -> String? {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: getInstallMessageSignature: SDK not initialized", type: .error)
+            }
+            return nil
+        }
+        return Approov.getInstallMessageSignature(message)
+    }
+
+    /**
+     * Legacy getMessageSignature.
+     */
+    @available(*, deprecated, message: "Use getAccountMessageSignature or getInstallMessageSignature instead.")
+    public static func getMessageSignature(message: String) throws -> String {
+        guard let signature = getAccountMessageSignature(message: message) else {
+            throw ApproovError.permanentError(message: "getMessageSignature: signature unavailable")
+        }
+        return signature
+    }
+
+    /**
+     * Fetches a secure string with the given key.
      */
     public static func fetchSecureString(key: String, newDef: String?) throws -> String? {
-        // Determine the type of operation as the values themselves cannot be logged
-        var type = "lookup"
-        if newDef != nil {
-            type = "definition"
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: fetchSecureString: SDK not initialized", type: .error)
+            }
+            throw ApproovError.permanentError(message: "fetchSecureString: SDK not initialized")
         }
-        // Fetch the secure string
+        let type = newDef != nil ? "definition" : "lookup"
         let approovResult = Approov.fetchSecureStringAndWait(key, newDef)
-        os_log("ApproovService: fetchSecureString: %@: %@", type: .info, type, Approov.string(from: approovResult.status))
-        // Process the returned Approov status
-        switch approovResult.status {
-        case .success,
-            .unknownKey:
-            break
-        case .disabled:
-            throw ApproovError.configurationError(message: "fetchSecureString: secure string feature disabled")
-        case .badKey:
-            throw ApproovError.permanentError(message: "fetchSecureString: secure string unknown key")
-        case .rejected:
-            // If the request is rejected then we provide a special exception with additional information
-            throw ApproovError.rejectionError(message: "fetchSecureString: rejected", ARC: approovResult.arc,
-                rejectionReasons: approovResult.rejectionReasons)
-        case .noNetwork,
-            .poorNetwork,
-            .mitmDetected:
-            // We are unable to get the secure string due to network conditions so the request can
-            // be retried by the user later
-            throw ApproovError.networkingError(message: "fetchSecureString: network issue, retry needed")
-        default:
-            // We are unable to get the secure string due to a more permanent error
-            throw ApproovError.permanentError(message: "fetchSecureString: " +
-                Approov.string(from: approovResult.status))
-
+        if loggingLevel >= .info {
+            os_log("ApproovService: fetchSecureString: %@: %@", type: .info, type, Approov.string(from: approovResult.status))
         }
+        try getServiceMutator().handleFetchSecureStringResult(approovResult, operation: type, key: key)
         return approovResult.secureString
     }
 
     /**
-     * Fetches a custom JWT with the given payload. Note that this call will require network
-     * transaction and thus will block for some time, so should not be called from the UI thread.
-     * If the fetch fails for any reason an exception will be thrown. Exceptions could be due to
-     * malformed JSON string provided (then a ApproovError.permanentError is raised), the feature not
-     * being enabled from the CLI tools (ApproovError.configurationError type raised), a rejection throws
-     * a ApproovError.rejectionError type which might include additional information regarding the failure
-     * reason. An Approov.networkingError exception should allow a retry operation to be performed. Finally
-     * if some other error occurs an Approov.permanentError is raised.
-     *
-     * @param payload is the marshaled JSON object for the claims to be included
-     * @return custom JWT string
-     * @throws exception with description of cause
+     * Fetches a custom JWT with the given payload.
      */
     public static func fetchCustomJWT(payload: String) throws -> String {
-        // Fetch the custom JWT
-        let approovResult = Approov.fetchCustomJWTAndWait(payload)
-        // Log result of token fetch operation but do not log the value
-        os_log("ApproovService: fetchCustomJWT: %@", type: .info, Approov.string(from: approovResult.status))
-        // Process the returned Approov status
-        switch approovResult.status {
-        case .success:
-            break
-        case .badPayload:
-            throw ApproovError.permanentError(message: "fetchCustomJWT: malformed JSON")
-        case .disabled:
-            throw ApproovError.configurationError(message: "fetchCustomJWT: feature not enabled")
-        case .rejected:
-            // If the request is rejected then we provide a special exception with additional information
-            throw ApproovError.rejectionError(message: "fetchCustomJWT: rejected", ARC: approovResult.arc,
-                rejectionReasons: approovResult.rejectionReasons)
-        case .noNetwork,
-            .poorNetwork,
-            .mitmDetected:
-            // We are unable to get the custom JWT due to network conditions so the request can
-            // be retried by the user later
-            throw ApproovError.networkingError(message: "fetchCustomJWT: network issue, retry needed")
-        default:
-            // We are unable to get the custom JWT due to a more permanent error
-            throw ApproovError.permanentError(message: "fetchCustomJWT: " + Approov.string(from: approovResult.status))
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: fetchCustomJWT: SDK not initialized", type: .error)
+            }
+            throw ApproovError.permanentError(message: "fetchCustomJWT: SDK not initialized")
         }
+        let approovResult = Approov.fetchCustomJWTAndWait(payload)
+        if loggingLevel >= .info {
+            os_log("ApproovService: fetchCustomJWT: %@", type: .info, Approov.string(from: approovResult.status))
+        }
+        try getServiceMutator().handleFetchCustomJWTResult(approovResult)
         return approovResult.token
     }
 
     /**
-     * Performs a precheck to determine if the app will pass attestation. This requires secure
-     * strings to be enabled for the account, although no strings need to be set up. This will
-     * likely require network access so may take some time to complete. It may throw an exception
-     * if the precheck fails or if there is some other problem. Exceptions could be due to
-     * a rejection (throws a ApproovError.rejectionError) type which might include additional
-     * information regarding the rejection reason. An ApproovError.networkingError exception should
-     * allow a retry operation to be performed and finally if some other error occurs an
-     * ApproovError.permanentError is raised.
+     * Performs a precheck.
      */
     public static func precheck() throws {
-        // Try to fetch a non-existent secure string in order to check for a rejection
-        let approovResults = Approov.fetchSecureStringAndWait("precheck-dummy-key", nil)
-        // Process the returned Approov status
-        switch approovResults.status {
-        case .success,
-            .unknownKey:
-            break
-        case .rejected:
-            // If the request is rejected then we provide a special exception with additional information
-            throw ApproovError.rejectionError(message: "precheck: rejected", ARC: approovResults.arc,
-                rejectionReasons: approovResults.rejectionReasons)
-        case .noNetwork,
-            .poorNetwork,
-            .mitmDetected:
-            // We are unable to get the secure string due to network conditions so the request can
-            // be retried by the user later
-            throw ApproovError.networkingError(message: "precheck: network issue, retry needed")
-        default:
-            // We are unable to get the secure string due to a more permanent error
-            throw ApproovError.permanentError(message: "precheck: " + Approov.string(from: approovResults.status))
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: precheck: SDK not initialized", type: .error)
+            }
+            throw ApproovError.permanentError(message: "precheck: SDK not initialized")
         }
+        let approovResults = Approov.fetchSecureStringAndWait("precheck-dummy-key", nil)
+        if approovResults.status == ApproovTokenFetchStatus.unknownKey {
+            if loggingLevel >= .debug {
+                os_log("ApproovService: precheck: success", type: .debug)
+            }
+        } else {
+            if loggingLevel >= .debug {
+                os_log("ApproovService: precheck: %@", type: .debug, Approov.string(from: approovResults.status))
+            }
+        }
+        try getServiceMutator().handlePrecheckResult(approovResults)
     }
 
     /**
      * Gets the last ARC (Attestation Response Code) code.
-     *
-     * NOTE: You MUST only call this method upon succesfull attestation completion. Any networking
-     * errors returned from the service layer will not return a meaningful ARC code if the method is called!!!
-     * @return String ARC from last attestation request or empty string if network unavailable
      */
     public static func getLastARC() -> String {
-        // We have to get the current config and obtain one protected API endpoint at least
-        // get the dynamic pins from Approov
-        guard let approovPins = Approov.getPins("public-key-sha256") else {
-            os_log("ApproovService: no host pinning information available", type: .error)
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: getLastARC: SDK not initialized", type: .error)
+            }
             return ""
         }
-        // The approovPins contains a map of hostnames to pin strings. We need to skip the '*' entry (Managed Trust Roots),
-        // and use another hostname if available.
+        guard let approovPins = Approov.getPins("public-key-sha256") else {
+            if loggingLevel >= .error {
+                os_log("ApproovService: no host pinning information available", type: .error)
+            }
+            return ""
+        }
         if let hostname = approovPins.keys.first(where: { $0 != "*" }) {
             let result = Approov.fetchTokenAndWait(hostname)
-            // Check if a token was fetched successfully and return its arc code
             if result.token.count > 0 {
                 return result.arc
             }
         }
-        os_log("ApproovService: ARC code unavailable", type: .info)
+        if loggingLevel >= .info {
+            os_log("ApproovService: ARC code unavailable", type: .info)
+        }
         return ""
     }
-
 }

--- a/Sources/ApproovAsyncHTTPClient/ApproovService.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovService.swift
@@ -199,6 +199,7 @@ public class ApproovService {
             failureCacheLock.withLock {
                 cachedFailureResult = nil
                 cachedFailureTime = nil
+                failureCacheMissGroup = nil
             }
 
             approovSDKInitialised = true
@@ -232,6 +233,7 @@ public class ApproovService {
         failureCacheLock.withLock {
             cachedFailureResult = nil
             cachedFailureTime = nil
+            failureCacheMissGroup = nil
         }
     }
 
@@ -536,7 +538,7 @@ public class ApproovService {
      */
     public static func updateRequestWithApproov(request: ApproovRequest) -> ApproovUpdateResponse {
         let url = request.url
-        var changes = ApproovRequestMutations()
+        let changes = ApproovRequestMutations()
 
         if !isApproovEnabled() {
             if loggingLevel >= .info {
@@ -622,8 +624,7 @@ public class ApproovService {
         }
         let traceID = approovResult.traceID
         if let traceHeader = stateLock.withLock({ _approovTraceIDHeader }),
-           !traceHeader.isEmpty,
-           !traceID.isEmpty {
+           !traceHeader.isEmpty {
             hasChanges = true
             setTraceIDHeaderKey = traceHeader
             setTraceIDHeaderValue = traceID
@@ -644,8 +645,10 @@ public class ApproovService {
                     do {
                         if try mutator.handleInterceptorHeaderSubstitutionResult(approovResults, header: header) {
                             if let secureStringResult = approovResults.secureString {
-                                hasChanges = true
-                                setSubstitutionHeaders[header] = prefix + secureStringResult
+                                if !secureStringResult.isEmpty {
+                                    hasChanges = true
+                                    setSubstitutionHeaders[header] = prefix + secureStringResult
+                                }
                             } else {
                                 response.decision = .ShouldFail
                                 response.error = ApproovError.permanentError(message: "Header substitution: key lookup error")
@@ -667,10 +670,13 @@ public class ApproovService {
         var updateURLString = url.absoluteString
         for entry in subsQueryParamsCopy {
             let urlStringRange = NSRange(updateURLString.startIndex..<updateURLString.endIndex, in: updateURLString)
-            let regex = try! NSRegularExpression(pattern: #"[\\?&]"# + entry + #"=([^&;]+)"#, options: [])
+            let escapedEntry = NSRegularExpression.escapedPattern(for: entry)
+            guard let regex = try? NSRegularExpression(pattern: #"[\\?&]"# + escapedEntry + #"=([^&;]+)"#, options: []) else {
+                continue
+            }
             let matches: [NSTextCheckingResult] = regex.matches(in: updateURLString, options: [], range: urlStringRange)
-            for match: NSTextCheckingResult in matches {
-                for rangeIndex in 1..<match.numberOfRanges {
+            for match: NSTextCheckingResult in matches.reversed() {
+                for rangeIndex in (1..<match.numberOfRanges).reversed() {
                     let matchRange = match.range(at: rangeIndex)
                     if let substringRange = Range(matchRange, in: updateURLString) {
                         let queryValue = String(updateURLString[substringRange])
@@ -683,15 +689,17 @@ public class ApproovService {
                         do {
                             if try mutator.handleInterceptorQueryParamSubstitutionResult(approovResults, queryKey: entry) {
                                 if let secureStringResult = approovResults.secureString {
-                                    hasChanges = true
-                                    queryKeys.append(entry)
-                                    updateURLString.replaceSubrange(Range(matchRange, in: updateURLString)!, with: secureStringResult)
-                                    updateURL = URL(string: updateURLString)
-                                    if updateURL == nil {
-                                        response.decision = .ShouldFail
-                                        response.error = ApproovError.permanentError(
-                                            message: "Query parameter substitution for \(entry): malformed URL \(updateURLString)")
-                                        return response
+                                    if !secureStringResult.isEmpty {
+                                        hasChanges = true
+                                        queryKeys.append(entry)
+                                        updateURLString.replaceSubrange(Range(matchRange, in: updateURLString)!, with: secureStringResult)
+                                        updateURL = URL(string: updateURLString)
+                                        if updateURL == nil {
+                                            response.decision = .ShouldFail
+                                            response.error = ApproovError.permanentError(
+                                                message: "Query parameter substitution for \(entry): malformed URL \(updateURLString)")
+                                            return response
+                                        }
                                     }
                                 }
                             }

--- a/Sources/ApproovAsyncHTTPClient/ApproovService.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovService.swift
@@ -204,7 +204,7 @@ public class ApproovService {
 
             approovSDKInitialised = true
             if isEnabled {
-                Approov.setUserProperty("approov-service-asynchttpclient/3.5.4")
+                Approov.setUserProperty("approov-service-asynchttpclient/dev")
             }
             TLSConfiguration.setVerifyPinningBlock(newValue: ApproovPinningVerifier.verifyPinning)
         }

--- a/Sources/ApproovAsyncHTTPClient/ApproovServiceMutator.swift
+++ b/Sources/ApproovAsyncHTTPClient/ApproovServiceMutator.swift
@@ -1,0 +1,353 @@
+// MIT License
+//
+// Copyright (c) 2016-present, Approov Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+// (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+// ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import Approov
+import Foundation
+import NIOHTTP1
+
+/**
+ * ApproovRequest stores information about a request being processed for Approov.
+ */
+public struct ApproovRequest {
+    public var url: URL
+    public var method: String
+    public var headers: HTTPHeaders
+    public var body: Data?
+
+    public init(url: URL, method: String, headers: HTTPHeaders, body: Data? = nil) {
+        self.url = url
+        self.method = method
+        self.headers = headers
+        self.body = body
+    }
+}
+
+/**
+ * ApproovFetchDecision defines the possible results from an Approov request update.
+ */
+public enum ApproovFetchDecision {
+    case ShouldProceed      // Proceed with request
+    case ShouldRetry        // User can retry request
+    case ShouldFail         // Request should not be made
+    case ShouldIgnore       // Do not process request
+}
+
+/**
+ * ApproovUpdateResponse contains the result of adding Approov protection to a request.
+ */
+public struct ApproovUpdateResponse {
+    public internal(set) var request: ApproovRequest
+    public internal(set) var decision: ApproovFetchDecision
+    public internal(set) var sdkMessage: String
+    public internal(set) var error: Error?
+}
+
+/**
+ * ApproovRequestMutations stores information about changes made to a network request
+ * during Approov processing, such as token headers, substituted headers, and query parameters.
+ */
+public class ApproovRequestMutations {
+    private var tokenHeaderKey: String?
+    private var traceIDHeaderKey: String?
+    private var substitutionHeaderKeys: [String] = []
+    private var originalURL: String?
+    private var substitutionQueryParamKeys: [String] = []
+
+    public init() {}
+
+    public func getTokenHeaderKey() -> String? {
+        return tokenHeaderKey
+    }
+
+    public func setTokenHeaderKey(_ tokenHeaderKey: String) {
+        self.tokenHeaderKey = tokenHeaderKey
+    }
+
+    public func getTraceIDHeaderKey() -> String? {
+        return traceIDHeaderKey
+    }
+
+    public func setTraceIDHeaderKey(_ traceIDHeaderKey: String?) {
+        self.traceIDHeaderKey = traceIDHeaderKey
+    }
+
+    public func getSubstitutionHeaderKeys() -> [String] {
+        return substitutionHeaderKeys
+    }
+
+    public func setSubstitutionHeaderKeys(_ substitutionHeaderKeys: [String]) {
+        self.substitutionHeaderKeys = substitutionHeaderKeys
+    }
+
+    public func getOriginalURL() -> String? {
+        return originalURL
+    }
+
+    public func getSubstitutionQueryParamKeys() -> [String] {
+        return substitutionQueryParamKeys
+    }
+
+    public func setSubstitutionQueryParamResults(originalURL: String, substitutionQueryParamKeys: [String]) {
+        self.originalURL = originalURL
+        self.substitutionQueryParamKeys = substitutionQueryParamKeys
+    }
+}
+
+/**
+ * ApproovServiceMutator provides an interface for modifying the behavior of
+ * the ApproovService class by overriding the default implementations of the
+ * defined callbacks. Opportunities to modify behavior are offered at key
+ * points in the service and attestation flows.
+ */
+public protocol ApproovServiceMutator {
+    /**
+     * Decides how to handle the token fetch result from an
+     * ApproovService.precheck() operation.
+     */
+    func handlePrecheckResult(_ approovResults: ApproovTokenFetchResult) throws
+
+    /**
+     * Decides how to handle the token fetch result from an
+     * ApproovService.fetchToken() operation.
+     */
+    func handleFetchTokenResult(_ approovResults: ApproovTokenFetchResult) throws
+
+    /**
+     * Decides how to handle the token fetch result from an
+     * ApproovService.fetchSecureString() operation.
+     */
+    func handleFetchSecureStringResult(_ approovResults: ApproovTokenFetchResult,
+                                       operation: String,
+                                       key: String) throws
+
+    /**
+     * Decides how to handle the token fetch result from an
+     * ApproovService.fetchCustomJWT() operation.
+     */
+    func handleFetchCustomJWTResult(_ approovResults: ApproovTokenFetchResult) throws
+
+    /**
+     * Decides whether a request should be processed in the interceptor or not.
+     * Called at the start of the ApproovService interceptor processing.
+     */
+    func handleInterceptorShouldProcessRequest(_ request: ApproovRequest) throws -> Bool
+
+    /**
+     * Decides how to handle the token fetch result from a call to
+     * Approov.fetchTokenAndWait() from within the interceptor.
+     */
+    func handleInterceptorFetchTokenResult(_ approovResults: ApproovTokenFetchResult,
+                                           url: String) throws -> Bool
+
+    /**
+     * Decides how to handle the token fetch result while substituting headers
+     * from within the interceptor.
+     */
+    func handleInterceptorHeaderSubstitutionResult(_ approovResults: ApproovTokenFetchResult,
+                                                   header: String) throws -> Bool
+
+    /**
+     * Decides how to handle the token fetch result while substituting query params
+     * from within the interceptor.
+     */
+    func handleInterceptorQueryParamSubstitutionResult(_ approovResults: ApproovTokenFetchResult,
+                                                       queryKey: String) throws -> Bool
+
+    /**
+     * Called after Approov has processed a network request, allowing further
+     * modifications.
+     */
+    func handleInterceptorProcessedRequest(_ request: ApproovRequest,
+                                           changes: ApproovRequestMutations) throws -> ApproovRequest
+
+    /**
+     * Decides whether certificate pinning should be applied to a hostname or not.
+     */
+    func handlePinningShouldProcessRequest(hostname: String) -> Bool
+}
+
+public extension ApproovServiceMutator {
+    func handlePrecheckResult(_ approovResults: ApproovTokenFetchResult) throws {
+        let status = approovResults.status
+        switch status {
+        case .rejected:
+            throw ApproovError.rejectionError(message: "precheck: rejected",
+                                              ARC: approovResults.arc,
+                                              rejectionReasons: approovResults.rejectionReasons)
+        case .noNetwork,
+             .poorNetwork,
+             .mitmDetected:
+            throw ApproovError.networkingError(message: "precheck network error: " + Approov.string(from: status))
+        case .success,
+             .unknownKey:
+            return
+        default:
+            throw ApproovError.permanentError(message: "precheck: " + Approov.string(from: status))
+        }
+    }
+
+    func handleFetchTokenResult(_ approovResults: ApproovTokenFetchResult) throws {
+        let status = approovResults.status
+        switch status {
+        case .success:
+            return
+        case .noNetwork,
+             .poorNetwork,
+             .mitmDetected:
+            throw ApproovError.networkingError(message: "fetchToken network error: " + Approov.string(from: status))
+        default:
+            throw ApproovError.permanentError(message: "fetchToken: " + Approov.string(from: status))
+        }
+    }
+
+    func handleFetchSecureStringResult(_ approovResults: ApproovTokenFetchResult,
+                                       operation: String,
+                                       key: String) throws {
+        let status = approovResults.status
+        switch status {
+        case .rejected:
+            throw ApproovError.rejectionError(message: "fetchSecureString \(operation) for \(key): rejected",
+                                              ARC: approovResults.arc,
+                                              rejectionReasons: approovResults.rejectionReasons)
+        case .noNetwork,
+             .poorNetwork,
+             .mitmDetected:
+            throw ApproovError.networkingError(message: "fetchSecureString \(operation) for \(key): " +
+                                               Approov.string(from: status))
+        case .success,
+             .unknownKey:
+            return
+        default:
+            throw ApproovError.permanentError(message: "fetchSecureString \(operation) for \(key): " +
+                                              Approov.string(from: status))
+        }
+    }
+
+    func handleFetchCustomJWTResult(_ approovResults: ApproovTokenFetchResult) throws {
+        let status = approovResults.status
+        switch status {
+        case .rejected:
+            throw ApproovError.rejectionError(message: "fetchCustomJWT: rejected",
+                                              ARC: approovResults.arc,
+                                              rejectionReasons: approovResults.rejectionReasons)
+        case .noNetwork,
+             .poorNetwork,
+             .mitmDetected:
+            throw ApproovError.networkingError(message: "fetchCustomJWT network error: " + Approov.string(from: status))
+        case .success:
+            return
+        default:
+            throw ApproovError.permanentError(message: "fetchCustomJWT: " + Approov.string(from: status))
+        }
+    }
+
+    func handleInterceptorShouldProcessRequest(_ request: ApproovRequest) throws -> Bool {
+        let urlString = request.url.absoluteString
+        let urlStringRange = NSRange(urlString.startIndex..<urlString.endIndex, in: urlString)
+        for (_, regex) in ApproovService.getExclusionURLRegexs() {
+            if regex.firstMatch(in: urlString, options: [], range: urlStringRange) != nil {
+                return false
+            }
+        }
+        return true
+    }
+
+    func handleInterceptorFetchTokenResult(_ approovResults: ApproovTokenFetchResult,
+                                           url: String) throws -> Bool {
+        let status = approovResults.status
+        switch status {
+        case .success:
+            return true
+        case .noNetwork,
+             .poorNetwork,
+             .mitmDetected:
+            throw ApproovError.networkingError(message: "Approov token fetch for \(url): " +
+                                               Approov.string(from: status))
+        case .noApproovService,
+             .unknownURL,
+             .unprotectedURL:
+            return false
+        default:
+            throw ApproovError.permanentError(message: "Approov token fetch for \(url): " +
+                                              Approov.string(from: status))
+        }
+    }
+
+    func handleInterceptorHeaderSubstitutionResult(_ approovResults: ApproovTokenFetchResult,
+                                                   header: String) throws -> Bool {
+        let status = approovResults.status
+        switch status {
+        case .success:
+            return true
+        case .rejected:
+            throw ApproovError.rejectionError(message: "Header substitution for \(header): rejected",
+                                              ARC: approovResults.arc,
+                                              rejectionReasons: approovResults.rejectionReasons)
+        case .noNetwork,
+             .poorNetwork,
+             .mitmDetected:
+            throw ApproovError.networkingError(message: "Header substitution for \(header): " +
+                                               Approov.string(from: status))
+        case .unknownKey:
+            return false
+        default:
+            throw ApproovError.permanentError(message: "Header substitution for \(header): " +
+                                              Approov.string(from: status))
+        }
+    }
+
+    func handleInterceptorQueryParamSubstitutionResult(_ approovResults: ApproovTokenFetchResult,
+                                                       queryKey: String) throws -> Bool {
+        let status = approovResults.status
+        switch status {
+        case .success:
+            return true
+        case .rejected:
+            throw ApproovError.rejectionError(message: "Query parameter substitution for \(queryKey): rejected",
+                                              ARC: approovResults.arc,
+                                              rejectionReasons: approovResults.rejectionReasons)
+        case .noNetwork,
+             .poorNetwork,
+             .mitmDetected:
+            throw ApproovError.networkingError(message: "Query parameter substitution for \(queryKey): " +
+                                               Approov.string(from: status))
+        case .unknownKey:
+            return false
+        default:
+            throw ApproovError.permanentError(message: "Query parameter substitution for \(queryKey): " +
+                                              Approov.string(from: status))
+        }
+    }
+
+    func handleInterceptorProcessedRequest(_ request: ApproovRequest,
+                                           changes: ApproovRequestMutations) throws -> ApproovRequest {
+        return request
+    }
+
+    func handlePinningShouldProcessRequest(hostname: String) -> Bool {
+        return true
+    }
+}
+
+public struct ApproovServiceMutatorDefault: ApproovServiceMutator, CustomStringConvertible {
+    public static let shared = ApproovServiceMutatorDefault()
+
+    public var description: String {
+        return "ApproovServiceMutator.DEFAULT"
+    }
+
+    private init() {}
+}

--- a/Sources/ApproovAsyncHTTPClient/util/http-sfv/SFV.swift
+++ b/Sources/ApproovAsyncHTTPClient/util/http-sfv/SFV.swift
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright (c) 2025-present, Approov Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+// (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+// ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import RawStructuredFieldValues
+import Foundation
+
+public class SFV {
+
+    static func serializeStringItem(item: StringItem) throws -> String? {
+        var serializer = StructuredFieldValueSerializer()
+        let serialized = try serializer.writeItemFieldValue(item.item)
+        let string = String(data: Data(serialized), encoding: .utf8)
+        return string
+    }
+
+    static func serializeList(list: InnerList) throws -> String? {
+        var serializer = StructuredFieldValueSerializer()
+        let itemOrInnerList = ItemOrInnerList.innerList(list)
+        let serialized = try serializer.writeListFieldValue([itemOrInnerList])
+        let string = String(data: Data(serialized), encoding: .utf8)
+        return string
+    }
+
+    // Method to serialize dictionary entry of sigId: signatureBase64 of type String: UndecodedByteSequence
+    static func serializeDictionary(key: String, data: Data) throws -> String?
+    {
+        var serializer = StructuredFieldValueSerializer()
+        let dataBase64: String = data.base64EncodedString()
+        let dictionary: OrderedMap<String, ItemOrInnerList> =
+            [key: ItemOrInnerList.item(Item(bareItem: RFC9651BareItem.undecodedByteSequence(dataBase64), parameters: [:]))]
+        let serialized: [UInt8] = try serializer.writeDictionaryFieldValue(dictionary)
+        let string = String(data: Data(serialized), encoding: .utf8)
+        return string
+    }
+
+    // Method to serialize dictionary entry of key: sigParams of type String: InnerList
+    static func serializeDictionary(key: String, innerList: InnerList) throws -> String? {
+        var serializer = StructuredFieldValueSerializer()
+        let dictionary: OrderedMap<String, ItemOrInnerList> = [key: ItemOrInnerList.innerList(innerList)]
+        let serialized = try serializer.writeDictionaryFieldValue(dictionary)
+        let string = String(data: Data(serialized), encoding: .utf8)
+        return string
+    }
+}

--- a/Sources/ApproovAsyncHTTPClient/util/http-sfv/StringItem.swift
+++ b/Sources/ApproovAsyncHTTPClient/util/http-sfv/StringItem.swift
@@ -1,0 +1,55 @@
+// MIT License
+//
+// Copyright (c) 2025-present, Approov Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+// (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+// ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import RawStructuredFieldValues
+
+/**
+ * A StringItem is a structured field value item that represents a string with optional parameters.
+ */
+public struct StringItem {
+    var item: Item
+
+    public init(value: String) {
+        item = Item(bareItem: RFC9651BareItem.string(value), parameters: [:])
+    }
+
+    public init(value: String, parameters: OrderedMap<String, RFC9651BareItem>) {
+        item = Item(bareItem: RFC9651BareItem.string(value), parameters: parameters)
+    }
+
+    var value: String {
+        switch item.rfc9651BareItem {
+        case .string(let string):
+            let check: String = string
+            return check
+        default:
+            return ""
+        }
+    }
+
+    var parameters: OrderedMap<String, String> {
+        var paramsAsStrings = OrderedMap<String, String>()
+        for (key, value) in item.rfc9651Parameters {
+            switch value {
+            case .string(let string):
+                paramsAsStrings[key] = string
+            default:
+                continue
+            }
+        }
+        return paramsAsStrings
+    }
+}

--- a/Sources/ApproovAsyncHTTPClient/util/sig/ComponentProvider.swift
+++ b/Sources/ApproovAsyncHTTPClient/util/sig/ComponentProvider.swift
@@ -1,0 +1,175 @@
+import Foundation
+import RawStructuredFieldValues
+
+
+// Gets items from the request
+protocol ComponentProvider {
+    // Component Identifiers
+    static var DC_METHOD: String { get }
+    static var DC_AUTHORITY: String { get }
+    static var DC_SCHEME: String { get }
+    static var DC_TARGET_URI: String { get }
+    static var DC_REQUEST_TARGET: String { get }
+    static var DC_PATH: String { get }
+    static var DC_QUERY: String { get }
+    static var DC_QUERY_PARAM: String { get }
+
+    // For requests
+    func getMethod() -> String
+    func getAuthority() -> String
+    func getScheme() -> String
+    func getTargetUri() -> String
+    func getRequestTarget() -> String
+    func getPath() -> String
+    func getQuery() -> String
+    func getQueryParam(name: String) -> String?
+    func hasBody() -> Bool
+
+    // Fields
+    func hasField(name: String) -> Bool
+    func getField(name: String) -> String?
+    static func combineFieldValues(fields: [String]?) -> String?
+
+    func getComponentValue(componentIdentifier: StringItem) throws -> String?
+}
+
+enum ComponentProviderError: Error {
+    case missingParameter(String)
+    case unknownComponent(String)
+    case invalidFieldValue(String)
+}
+
+extension ComponentProvider {
+
+    // Defaults for component identifiers
+    static var DC_METHOD: String { "@method" }
+    static var DC_AUTHORITY: String { "@authority" }
+    static var DC_SCHEME: String { "@scheme" }
+    static var DC_TARGET_URI: String { "@target-uri" }
+    static var DC_REQUEST_TARGET: String { "@request-target" }
+    static var DC_PATH: String { "@path" }
+    static var DC_QUERY: String { "@query" }
+    static var DC_QUERY_PARAM: String { "@query-param" }
+
+    static func combineFieldValues(fields: [String]?) -> String? {
+        guard let fields = fields else {
+            return nil
+        }
+
+        var result = [String]()
+        for field in fields {
+            let trimmedField = field.trimmingCharacters(in: .whitespacesAndNewlines)
+            let replacedField = trimmedField.replacingOccurrences(of: "\\s*\\r\\n\\s*", with: " ", options: .regularExpression)
+            result.append(replacedField)
+        }
+        return result.isEmpty ? nil : result.joined(separator: ", ")
+    }
+
+    func getComponentValue(componentIdentifier: StringItem) throws -> String? {
+        let baseIdentifier = componentIdentifier.value
+        if baseIdentifier.starts(with: "@") {
+            // Derived component
+            switch baseIdentifier {
+            case Self.DC_METHOD:
+                return getMethod()
+            case Self.DC_AUTHORITY:
+                return getAuthority()
+            case Self.DC_SCHEME:
+                return getScheme()
+            case Self.DC_TARGET_URI:
+                return getTargetUri()
+            case Self.DC_REQUEST_TARGET:
+                return getRequestTarget()
+            case Self.DC_PATH:
+                return getPath()
+            case Self.DC_QUERY:
+                return getQuery()
+            case Self.DC_QUERY_PARAM:
+                if let nameParameter = componentIdentifier.parameters["name"] {
+                    return getQueryParam(name: nameParameter)
+                } else {
+                    throw ComponentProviderError.missingParameter("'name' parameter of \(baseIdentifier) is required")
+                }
+            default:
+                throw ComponentProviderError.unknownComponent("Unknown derived component: \(baseIdentifier)")
+            }
+        } else {
+            if let keyParameter = componentIdentifier.parameters["key"] {
+                if let fieldValue = getField(name: baseIdentifier),
+                   let fieldValueData = fieldValue.data(using: .utf8) {
+                    // Parse the field as a dictionary
+                    var parser = StructuredFieldValueParser(fieldValueData)
+                    let parsed = try parser.parseDictionaryFieldValue()
+                    if let dictionaryValue = parsed[keyParameter] {
+                        var serializer = StructuredFieldValueSerializer()
+                        switch dictionaryValue {
+                        case .item(let item):
+                            let serializedValue = try serializer.writeItemFieldValue(item)
+                            return String(data: Data(serializedValue), encoding: .utf8)
+                        case .innerList(let innerList):
+                            let itemOrInnerList = ItemOrInnerList.innerList(innerList)
+                            let serializedValue = try serializer.writeListFieldValue([itemOrInnerList])
+                            return String(data: Data(serializedValue), encoding: .utf8)
+                        }
+                    }
+                    throw ComponentProviderError.unknownComponent("Field value for \(baseIdentifier) not found")
+                }
+                throw ComponentProviderError.missingParameter("'key' parameter of \(baseIdentifier) is required")
+            } else if componentIdentifier.parameters["sf"] != nil {
+                switch (baseIdentifier) {
+                case "accept", "accept-ch", "accept-encoding", "accept-language", "accept-patch", "accept-ranges",
+                    "access-control-allow-headers", "access-control-allow-methods", "access-control-expose-headers",
+                    "access-control-request-headers", "alpn", "allow", "cache-status", "connection",
+                    "content-encoding", "content-language", "content-length", "example-list", "proxy-status",
+                    "te", "timing-allow-origin", "trailer", "transfer-encoding", "variant-key", "vary",
+                    "x-list", "x-list-a", "x-list-b", "x-xss-protection":
+                    // List
+                    if let fieldValue = getField(name: baseIdentifier),
+                       let fieldValueData = fieldValue.data(using: .utf8) {
+                        var parser = StructuredFieldValueParser(fieldValueData)
+                        let parsed = try parser.parseListFieldValue()
+                        var serializer = StructuredFieldValueSerializer()
+                        let serializedValue = try serializer.writeListFieldValue(parsed)
+                        return String(data: Data(serializedValue), encoding: .utf8)
+                    }
+                    throw ComponentProviderError.invalidFieldValue("Field \(baseIdentifier) is not a structured field")
+                case "alt-svc", "cache-control", "cdn-cache-control", "example-dict", "expect-ct", "keep-alive",
+                     "pragma", "prefer", "preference-applied", "priority", "signature", "signature-input",
+                     "surrogate-control", "variants", "x-dictionary":
+                     // Dictionary
+                    if let fieldValue = getField(name: baseIdentifier),
+                       let fieldValueData = fieldValue.data(using: .utf8) {
+                        var parser = StructuredFieldValueParser(fieldValueData)
+                        let parsed = try parser.parseDictionaryFieldValue()
+                        var serializer = StructuredFieldValueSerializer()
+                        let serializedValue = try serializer.writeDictionaryFieldValue(parsed)
+                        return String(data: Data(serializedValue), encoding: .utf8)
+                    }
+                    throw ComponentProviderError.invalidFieldValue("Field \(baseIdentifier) is not a structured field")
+                case "access-control-allow-credentials", "access-control-allow-origin", "access-control-max-age",
+                     "access-control-request-method", "age", "alt-used", "content-type", "cross-origin-resource-policy",
+                     "example-boolean", "example-bytesequence", "example-decimal", "example-integer", "example-string",
+                     "example-token", "expect", "host", "origin", "retry-after", "x-content-type-options", "x-frame-options":
+                    // Item
+                    if let fieldValue = getField(name: baseIdentifier),
+                       let fieldValueData = fieldValue.data(using: .utf8) {
+                        var parser = StructuredFieldValueParser(fieldValueData)
+                        let parsed = try parser.parseItemFieldValue()
+                        var serializer = StructuredFieldValueSerializer()
+                        let serializedValue = try serializer.writeItemFieldValue(parsed)
+                        return String(data: Data(serializedValue), encoding: .utf8)
+                    }
+                    throw ComponentProviderError.invalidFieldValue("Field \(baseIdentifier) is not a structured field")
+                default:
+                    throw ComponentProviderError.invalidFieldValue("Field \(baseIdentifier) is not a structured field")
+                }
+            } else {
+                // Regular field
+                if let fieldValue = getField(name: baseIdentifier) {
+                    return fieldValue
+                }
+                throw ComponentProviderError.unknownComponent("Field value for \(baseIdentifier) not found")
+            }
+        }
+    }
+}

--- a/Sources/ApproovAsyncHTTPClient/util/sig/LICENSE
+++ b/Sources/ApproovAsyncHTTPClient/util/sig/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2026 Approov Integration Examples
+Copyright (c) 2022 Bespoke Engineering
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,6 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-NOTE: This repo also includes code from other repositories that have applied their own
-open source license of choice. Please see README.md for details.

--- a/Sources/ApproovAsyncHTTPClient/util/sig/SignatureBaseBuilder.swift
+++ b/Sources/ApproovAsyncHTTPClient/util/sig/SignatureBaseBuilder.swift
@@ -1,0 +1,42 @@
+import Foundation
+import RawStructuredFieldValues
+
+class SignatureBaseBuilder {
+    private let sigParams: SignatureParameters
+    private let ctx: ComponentProvider
+
+    init(sigParams: SignatureParameters, ctx: ComponentProvider) {
+        self.sigParams = sigParams
+        self.ctx = ctx
+    }
+
+    func createSignatureBase() throws -> String {
+        var base = ""
+
+        for componentIdentifier in sigParams.getComponentIdentifiers() {
+            if let componentValue = try ctx.getComponentValue(componentIdentifier: componentIdentifier) {
+                // Write out the line to the base
+                guard let compIdString = try SFV.serializeStringItem(item: componentIdentifier) else {
+                    throw ApproovError.permanentError(message: "Failed to serialize component identifier: \(componentIdentifier)")
+                }
+                base += "\(compIdString): \(componentValue)\n"
+            } else {
+                throw ApproovError.permanentError(message: "Couldn't find required component value for identifier: \(componentIdentifier)")
+            }
+        }
+
+        // Add the signature parameters line
+        // Serialize the signature parameters component identifier
+        guard let sigParamsIdString = try SFV.serializeStringItem(item: sigParams.toComponentIdentifier()) else {
+            throw ApproovError.permanentError(message: "Failed to serialize signature parameters component identifier")
+        }
+
+        // Serialize the signature params dictionary returned by toComponentValue()
+        guard let sigParamsString = try SFV.serializeList(list: sigParams.toComponentValue()) else {
+            throw ApproovError.permanentError(message: "Failed to serialize signature parameters component value")
+        }
+        base += "\(sigParamsIdString): \(sigParamsString)"
+
+        return base
+    }
+}

--- a/Sources/ApproovAsyncHTTPClient/util/sig/SignatureParameters.swift
+++ b/Sources/ApproovAsyncHTTPClient/util/sig/SignatureParameters.swift
@@ -57,6 +57,7 @@ public class SignatureParameters: CustomStringConvertible {
     /**
      * @param parameters the parameters to set
      */
+    @discardableResult
     func setParameters(_ parameters: OrderedMap<String, Any>) -> SignatureParameters {
         self.componentParameters = parameters
         return self
@@ -90,6 +91,7 @@ public class SignatureParameters: CustomStringConvertible {
     /**
      * @param alg the alg to set
      */
+    @discardableResult
     func setAlg(_ alg: String) -> SignatureParameters {
         componentParameters[Self.ALG] = alg
         return self
@@ -105,6 +107,7 @@ public class SignatureParameters: CustomStringConvertible {
     /**
      * @param created the created-at time to set
      */
+    @discardableResult
     func setCreated(_ created: Int64) -> SignatureParameters {
         componentParameters[Self.CREATED] = created
         return self
@@ -120,6 +123,7 @@ public class SignatureParameters: CustomStringConvertible {
     /**
      * @param expires the expires-at time to set
      */
+    @discardableResult
     func setExpires(_ expires: Int64) -> SignatureParameters {
         componentParameters[Self.EXPIRES] = expires
         return self
@@ -135,6 +139,7 @@ public class SignatureParameters: CustomStringConvertible {
     /**
      * @param keyid the keyid to set
      */
+    @discardableResult
     func setKeyid(_ keyid: String) -> SignatureParameters {
         componentParameters[Self.KEYID] = keyid
         return self
@@ -150,6 +155,7 @@ public class SignatureParameters: CustomStringConvertible {
     /**
      * @param nonce the nonce to set
      */
+    @discardableResult
     func setNonce(_ nonce: String) -> SignatureParameters {
         componentParameters[Self.NONCE] = nonce
         return self
@@ -165,6 +171,7 @@ public class SignatureParameters: CustomStringConvertible {
     /**
      * @param tag the tag to set
      */
+    @discardableResult
     func setTag(_ tag: String) -> SignatureParameters {
         componentParameters[Self.TAG] = tag
         return self
@@ -186,6 +193,7 @@ public class SignatureParameters: CustomStringConvertible {
      * @param key the key for which to set the custom parameter value
      * @param value the value to set for the custom parameter
      */
+    @discardableResult
     func setCustomParameter(_ key: String, value: Any) throws -> SignatureParameters {
         switch key {
         case Self.ALG:
@@ -282,6 +290,7 @@ public class SignatureParameters: CustomStringConvertible {
     /**
      * Add a component without parameters.
      */
+    @discardableResult
     func addComponentIdentifier(_ identifier: String) -> SignatureParameters {
         let normalizedIdentifier = identifier.starts(with: "@") ? identifier : identifier.lowercased()
         let stringItem = StringItem(value: normalizedIdentifier, parameters: [:])
@@ -304,6 +313,7 @@ public class SignatureParameters: CustomStringConvertible {
     /**
      * Add a component with optional parameters. Field components are assumed to be already set to lowercase.
      */
+    @discardableResult
     func addComponentIdentifier(_ identifier: StringItem) -> SignatureParameters {
         componentIdentifiers.append(identifier)
         return self

--- a/Sources/ApproovAsyncHTTPClient/util/sig/SignatureParameters.swift
+++ b/Sources/ApproovAsyncHTTPClient/util/sig/SignatureParameters.swift
@@ -1,0 +1,325 @@
+import Foundation
+import RawStructuredFieldValues
+
+public class SignatureParameters: CustomStringConvertible {
+    private static let SIGNATURE_PARAMS = "@signature-params"
+
+    private static let ALG = "alg"
+    private static let CREATED = "created"
+    private static let EXPIRES = "expires"
+    private static let KEYID = "keyid"
+    private static let NONCE = "nonce"
+    private static let TAG = "tag"
+
+    // set this to add an extra header to the request that includes the SHA256 of the signature base
+    // which can be used to aid debugging on the server side to determine if there is a problem with
+    // the reconstruction of the signature base or the verification of the signature.
+    private var debugMode: Bool = false
+
+    private var componentIdentifiers: [StringItem] = []
+
+    // This preserves insertion order
+    private var componentParameters: OrderedMap<String, Any> = [:]
+
+    /**
+     * Default constructor creates an empty SignatureParameters ready to be populated.
+     */
+    init() {
+        self.componentIdentifiers = []
+        self.componentParameters = [:]
+    }
+
+    /**
+     * Copy constructor creates a SignatureParameters instance pre-populated with a copy of all the
+     * component identifiers and parameters from the provided base.
+     *
+     * @param base
+     */
+    init(base: SignatureParameters) {
+        self.componentIdentifiers = base.componentIdentifiers // Copy the array
+        self.componentParameters = base.componentParameters // Copy the dictionary
+    }
+
+    /**
+     * @return the componentIdentifiers
+     */
+    func getComponentIdentifiers() -> [StringItem] {
+        return componentIdentifiers
+    }
+
+    /**
+     * @return the parameters
+     */
+    func getParameters() -> OrderedMap<String, Any> {
+        return componentParameters
+    }
+
+    /**
+     * @param parameters the parameters to set
+     */
+    func setParameters(_ parameters: OrderedMap<String, Any>) -> SignatureParameters {
+        self.componentParameters = parameters
+        return self
+    }
+
+    /**
+     * Determine if debug mode has been set for this signature parameters instance
+     *
+     * @return true is debug mode is on; false otherwise
+     */
+    func isDebugMode() -> Bool {
+        return debugMode
+    }
+
+    /**
+     * Set the debug mode for this signature parameters
+     *
+     * @param debugMode true to enable; false to disable
+     */
+    func setDebugMode(_ debugMode: Bool) {
+        self.debugMode = debugMode
+    }
+
+    /**
+     * @return the alg
+     */
+    func getAlg() -> String? {
+        return componentParameters[Self.ALG] as? String
+    }
+
+    /**
+     * @param alg the alg to set
+     */
+    func setAlg(_ alg: String) -> SignatureParameters {
+        componentParameters[Self.ALG] = alg
+        return self
+    }
+
+    /**
+     * @return the created-at time in seconds since epoch
+     */
+    func getCreated() -> Int64? {
+        return componentParameters[Self.CREATED] as? Int64
+    }
+
+    /**
+     * @param created the created-at time to set
+     */
+    func setCreated(_ created: Int64) -> SignatureParameters {
+        componentParameters[Self.CREATED] = created
+        return self
+    }
+
+    /**
+     * @return the expires-at time in seconds since epoch
+     */
+    func getExpires() -> Int64? {
+        return componentParameters[Self.EXPIRES] as? Int64
+    }
+
+    /**
+     * @param expires the expires-at time to set
+     */
+    func setExpires(_ expires: Int64) -> SignatureParameters {
+        componentParameters[Self.EXPIRES] = expires
+        return self
+    }
+
+    /**
+     * @param expires the expires to set
+     */
+    func getKeyid() -> String? {
+        return componentParameters[Self.KEYID] as? String
+    }
+
+    /**
+     * @param keyid the keyid to set
+     */
+    func setKeyid(_ keyid: String) -> SignatureParameters {
+        componentParameters[Self.KEYID] = keyid
+        return self
+    }
+
+    /**
+     * @return the nonce
+     */
+    func getNonce() -> String? {
+        return componentParameters[Self.NONCE] as? String
+    }
+
+    /**
+     * @param nonce the nonce to set
+     */
+    func setNonce(_ nonce: String) -> SignatureParameters {
+        componentParameters[Self.NONCE] = nonce
+        return self
+    }
+
+    /**
+     * @return the tag
+     */
+    func getTag() -> String? {
+        return componentParameters[Self.TAG] as? String
+    }
+
+    /**
+     * @param tag the tag to set
+     */
+    func setTag(_ tag: String) -> SignatureParameters {
+        componentParameters[Self.TAG] = tag
+        return self
+    }
+
+    /**
+     * @param key the key for which to get the custom parameter value
+     */
+    func getCustomParameter(_ key: String) -> Any? {
+        return componentParameters[key]
+    }
+
+    enum SignatureParametersError: Error {
+        case invalidType(key: String, expectedType: String)
+        case encodingFailed(description: String)
+    }
+
+    /**
+     * @param key the key for which to set the custom parameter value
+     * @param value the value to set for the custom parameter
+     */
+    func setCustomParameter(_ key: String, value: Any) throws -> SignatureParameters {
+        switch key {
+        case Self.ALG:
+            guard let stringValue = value as? String else {
+                throw SignatureParametersError.invalidType(key: key, expectedType: "String")
+            }
+            return setAlg(stringValue)
+        case Self.CREATED:
+            guard let intValue = value as? Int64 else {
+                throw SignatureParametersError.invalidType(key: key, expectedType: "Int64")
+            }
+            return setCreated(intValue)
+        case Self.EXPIRES:
+            guard let intValue = value as? Int64 else {
+                throw SignatureParametersError.invalidType(key: key, expectedType: "Int64")
+            }
+            return setExpires(intValue)
+        case Self.KEYID:
+            guard let stringValue = value as? String else {
+                throw SignatureParametersError.invalidType(key: key, expectedType: "String")
+            }
+            return setKeyid(stringValue)
+        case Self.NONCE:
+            guard let stringValue = value as? String else {
+                throw SignatureParametersError.invalidType(key: key, expectedType: "String")
+            }
+            return setNonce(stringValue)
+        case Self.TAG:
+            guard let stringValue = value as? String else {
+                throw SignatureParametersError.invalidType(key: key, expectedType: "String")
+            }
+            return setTag(stringValue)
+        default:
+            // Allow other keys without type enforcement
+            componentParameters[key] = value
+            return self
+        }
+    }
+
+    func toComponentIdentifier() -> StringItem {
+        return StringItem(value: Self.SIGNATURE_PARAMS)
+    }
+
+    func toComponentValue() throws -> InnerList {
+        // Copy the componentIdentifiers
+        var identifiers: BareInnerList = BareInnerList()
+        for identifier in componentIdentifiers {
+            let bareItem = RFC9651BareItem.string(identifier.value)
+            var bareParams: OrderedMap<String, RFC9651BareItem> = [:]
+            for (key, value) in identifier.parameters {
+                bareParams[key] = RFC9651BareItem.string(value)
+            }
+            let item = Item(bareItem: bareItem, parameters: bareParams)
+            identifiers.append(item)
+        }
+
+        // Copy the componentParameters
+        var parameters: OrderedMap<String, RFC9651BareItem> = [:]
+        for (key, value) in componentParameters {
+            if let boolValue = value as? Bool {
+                parameters[key] = RFC9651BareItem.bool(boolValue)
+            } else if let intValue = value as? Int64 {
+                parameters[key] = RFC9651BareItem.integer(intValue)
+            } else if let doubleValue = value as? Double {
+                parameters[key] = try RFC9651BareItem.decimal(PseudoDecimal(doubleValue))
+            } else if let stringValue = value as? String {
+                parameters[key] = RFC9651BareItem.string(stringValue)
+            } else if let data = value as? Data {
+                parameters[key] = RFC9651BareItem.undecodedByteSequence(data.base64EncodedString())
+            } else if let date = value as? Date {
+                parameters[key] = RFC9651BareItem.date(Int64(date.timeIntervalSince1970))
+            } else {
+                throw ApproovError.permanentError(message: "Unsupported component parameter type: \(type(of: value))")
+            }
+        }
+
+        // Assemble the result
+        let componentValue = InnerList(bareInnerList: identifiers, parameters: parameters)
+        return componentValue
+    }
+
+    /**
+     * Check if a component identifier with the given name exists in the list of component identifiers.
+     * @param identifier the component identifier to check
+     * @return true if the component identifier exists; false otherwise
+     */
+    func containsComponentIdentifier(_ identifier: String) -> Bool {
+        let predicate: (StringItem) -> Bool = { existingIdentifier in
+            return existingIdentifier.value == identifier
+        }
+        return componentIdentifiers.contains(where: predicate)
+    }
+
+    /**
+     * Add a component without parameters.
+     */
+    func addComponentIdentifier(_ identifier: String) -> SignatureParameters {
+        let normalizedIdentifier = identifier.starts(with: "@") ? identifier : identifier.lowercased()
+        let stringItem = StringItem(value: normalizedIdentifier, parameters: [:])
+        componentIdentifiers.append(stringItem)
+        return self
+    }
+
+    /**
+     * Check if a component identifier exists in the list of component identifiers.
+     * @param identifier the component identifier to check
+     * @return true if the component identifier exists; false otherwise
+     */
+    func containsComponentIdentifier(_ identifier: StringItem) -> Bool {
+        let predicate: (StringItem) -> Bool = { existingIdentifier in
+            return existingIdentifier.value == identifier.value && existingIdentifier.parameters == identifier.parameters
+        }
+        return componentIdentifiers.contains(where: predicate)
+    }
+
+    /**
+     * Add a component with optional parameters. Field components are assumed to be already set to lowercase.
+     */
+    func addComponentIdentifier(_ identifier: StringItem) -> SignatureParameters {
+        componentIdentifiers.append(identifier)
+        return self
+    }
+
+    public var description: String {
+        do {
+            var serializer = StructuredFieldValueSerializer()
+            let itemOrInnerList = ItemOrInnerList.innerList(try toComponentValue())
+            let serializedValue = try serializer.writeListFieldValue([itemOrInnerList])
+            guard let description = String(data: Data(serializedValue), encoding: .utf8) else {
+                throw SignatureParametersError.encodingFailed(description: "UTF-8 encoding failed")
+            }
+            return "SignatureParameters: \(description)"
+        } catch let error {
+            return "SignatureParameters: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -545,6 +545,64 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
         }
     }
 
+    func testExtractBodyDataBuffersInMemoryBody() {
+        // An in-memory byteBuffer body completes synchronously and must be buffered in full.
+        let body = HTTPClient.Body.byteBuffer(ByteBuffer(string: "hello-body"))
+        XCTAssertEqual(ApproovService.extractBodyData(from: body), Data("hello-body".utf8))
+    }
+
+    func testExtractBodyDataAccumulatesMultipleChunks() {
+        // A repeatable, known-length body that emits several chunks must be accumulated in full,
+        // not reduced to only the final chunk (the previous getHTTPBody overwrite bug).
+        let body = HTTPClient.Body.stream(length: 6) { writer in
+            _ = writer.write(.byteBuffer(ByteBuffer(string: "abc")))
+            return writer.write(.byteBuffer(ByteBuffer(string: "def")))
+        }
+        XCTAssertEqual(ApproovService.extractBodyData(from: body), Data("abcdef".utf8))
+    }
+
+    func testExtractBodyDataSkipsOneShotStreamingBody() {
+        // A chunked streaming body (nil length) is treated as one-shot and must be skipped (nil)
+        // rather than consumed or partially digested.
+        let body = HTTPClient.Body.stream(length: nil) { writer in
+            writer.write(.byteBuffer(ByteBuffer(string: "streamed")))
+        }
+        XCTAssertNil(ApproovService.extractBodyData(from: body))
+    }
+
+    func testExtractBodyDataReturnsNilForNoBody() {
+        XCTAssertNil(ApproovService.extractBodyData(from: nil))
+    }
+
+    func testBodyDigestEnabledAddsContentDigestComponent() throws {
+        // Positive control: the default factory's SHA-256 digest adds a content-digest component.
+        let factory = try ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setBodyDigestConfig(ApproovDefaultMessageSigning.DIGEST_SHA256, required: false)
+        let request = ApproovRequest(url: URL(string: "https://example.com/path")!,
+                                     method: "POST",
+                                     headers: HTTPHeaders(),
+                                     body: Data("{\"test\": 1}".utf8))
+        let provider = ApproovAsyncHTTPClientComponentProvider(request: request)
+        let params = try factory.buildSignatureParameters(provider: provider, changes: ApproovRequestMutations())
+        XCTAssertTrue(params.containsComponentIdentifier("content-digest"),
+                      "content-digest component should be present when body digest is enabled")
+    }
+
+    func testBodyDigestDisabledViaNilAlgorithmOmitsContentDigest() throws {
+        // The default factory enables SHA-256 body digest; disabling it with a nil algorithm must
+        // prevent any content-digest component from being added to the signature parameters.
+        let factory = try ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setBodyDigestConfig(nil, required: false)
+        let request = ApproovRequest(url: URL(string: "https://example.com/path")!,
+                                     method: "POST",
+                                     headers: HTTPHeaders(),
+                                     body: Data("{\"test\": 1}".utf8))
+        let provider = ApproovAsyncHTTPClientComponentProvider(request: request)
+        let params = try factory.buildSignatureParameters(provider: provider, changes: ApproovRequestMutations())
+        XCTAssertFalse(params.containsComponentIdentifier("content-digest"),
+                       "content-digest component must be absent once body digest is disabled")
+    }
+
     // MARK: - §6 Secure Strings & Custom JWT
 
     func testFetchSecureStringReturnsConfiguredValue() throws {

--- a/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -1,0 +1,916 @@
+import XCTest
+import Foundation
+import NIOHTTP1
+import NIOCore
+import AsyncHTTPClient
+import NIOSSL
+@testable import ApproovAsyncHTTPClient
+import Approov
+import MiniSDKTestSupport
+import CryptoKit
+
+/// Integration tests for the ApproovService AsyncHTTPClient service layer.
+final class ApproovServiceMiniSDKTests: XCTestCase {
+    private let validInitialConfig = "#cb-ivol#mAxOF0ekJUOC36J5XWmVmVipOcUoEdMjhPSp2FVtyTo="
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MiniSDKAttesterProxyController.reset()
+        ApproovService.resetForTesting()
+        ApproovService.loggingLevel = .off
+        try initializeService(comment: "reinit-asynchttpclient-tests")
+    }
+
+    override func tearDown() {
+        ApproovService.setServiceMutator(nil)
+        MiniSDKAttesterProxyController.reset()
+        ApproovService.resetForTesting()
+        super.tearDown()
+    }
+
+    // MARK: - §1 Initialization
+
+    func testInitializeIgnoresSameConfigAndRejectsDifferentConfig() throws {
+        XCTAssertNoThrow(try ApproovService.initialize(config: validInitialConfig, comment: nil))
+
+        let differentConfig = "#cb-other#mAxOF0ekJUOC36J5XWmVmVipOcUoEdMjhPSp2FVtyTo="
+        XCTAssertThrowsError(try ApproovService.initialize(config: differentConfig, comment: nil)) { error in
+            guard case let ApproovError.initializationFailure(message) = error else {
+                return XCTFail("Expected initializationFailure, got \(error)")
+            }
+            XCTAssertTrue(message.contains("Approov SDK already initialized with a different configuration"),
+                          "Unexpected message: \(message)")
+        }
+    }
+
+    func testInitializeWithEmptyConfigForwardsPlainRequests() throws {
+        MiniSDKAttesterProxyController.reset()
+        let targetHost = try XCTUnwrap(URL(string: targetURLString)?.host)
+        let domainsJSON = "\"protectedDomains\": [\"\(targetHost)\"]"
+        MiniSDKAttesterProxyController.loadScenarioJSON(scenarioJSON(caseName: uniqueCaseName(prefix: "target-host"), body: domainsJSON))
+        ApproovService.resetForTesting()
+        ApproovService.loggingLevel = .off
+        try ApproovService.initialize(config: "", comment: "reinit-empty-config")
+
+        XCTAssertTrue(ApproovService.isInitialized())
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let reply = fetchNetworkReply(for: request)
+
+        XCTAssertNotNil(reply)
+        XCTAssertNil(getHeader(from: reply, key: "Approov-Token"))
+        XCTAssertNil(getHeader(from: reply, key: "Approov-TraceID"))
+    }
+
+    func testInitializeWithEmptyConfigCanLaterEnableApproov() throws {
+        MiniSDKAttesterProxyController.reset()
+        let targetHost = try XCTUnwrap(URL(string: targetURLString)?.host)
+        let domainsJSON = "\"protectedDomains\": [\"\(targetHost)\"]"
+        MiniSDKAttesterProxyController.loadScenarioJSON(scenarioJSON(caseName: uniqueCaseName(prefix: "target-host"), body: domainsJSON))
+        ApproovService.resetForTesting()
+        ApproovService.loggingLevel = .off
+        try ApproovService.initialize(config: "", comment: "reinit-empty-config")
+
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertFalse(ApproovService.isApproovEnabled())
+
+        let plainRequest = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let plainReply = fetchNetworkReply(for: plainRequest)
+        XCTAssertNotNil(plainReply)
+        XCTAssertNil(getHeader(from: plainReply, key: "Approov-Token"))
+        XCTAssertNil(getHeader(from: plainReply, key: "Approov-TraceID"))
+
+        try ApproovService.initialize(config: validInitialConfig, comment: nil)
+
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertTrue(ApproovService.isApproovEnabled())
+
+        let protectedRequest = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let protectedReply = fetchNetworkReply(for: protectedRequest)
+        XCTAssertNotNil(protectedReply)
+        XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-Token"))
+    }
+
+    func testInitializeSucceedsWhenNativeSdkAlreadyInitializedWithSameConfig() throws {
+        ApproovService.resetForTesting()
+
+        XCTAssertNoThrow(try ApproovService.initialize(config: validInitialConfig, comment: nil))
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertTrue(ApproovService.isApproovEnabled())
+    }
+
+    func testInitializeRejectsWhenNativeSdkAlreadyInitializedWithDifferentConfig() throws {
+        ApproovService.resetForTesting()
+        let differentConfig = "#cb-other#mAxOF0ekJUOC36J5XWmVmVipOcUoEdMjhPSp2FVtyTo="
+
+        XCTAssertThrowsError(try ApproovService.initialize(config: differentConfig, comment: nil)) { error in
+            guard case let ApproovError.initializationFailure(message) = error else {
+                return XCTFail("Expected initializationFailure, got \(error)")
+            }
+            XCTAssertEqual(message, "Error initializing Approov SDK: Approov SDK already initialized with a different configuration")
+        }
+
+        XCTAssertFalse(ApproovService.isInitialized())
+        XCTAssertFalse(ApproovService.isApproovEnabled())
+    }
+
+    // MARK: - §2 Request Processing & Token Behaviors
+
+    func testPrecheckTreatsUnknownKeyAsSuccess() throws {
+        XCTAssertNoThrow(try ApproovService.precheck())
+    }
+
+    func testGetDeviceIDReturnsMiniSDKDeviceID() {
+        XCTAssertEqual(ApproovService.getDeviceID(), "daIvmEWBA2gvZny7a/RC/w==")
+    }
+
+    func testUpdateRequestAddsTokenTraceBindingHashAndSubstitutions() throws {
+        let targetHost = try XCTUnwrap(URL(string: targetURLString)?.host)
+        try reinitializeService(
+            scenarioJSON: scenarioJSON(
+                caseName: uniqueCaseName(prefix: "substitutions"),
+                body: """
+                "protectedDomains": ["\(targetHost)"],
+                "initialSecureStrings": {
+                  "header-key": "header-secret",
+                  "query-key": "query-secret"
+                }
+                """
+            ),
+            comment: "reinit-substitutions"
+        )
+
+        ApproovService.bindHeader = "Authorization"
+        ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: nil)
+        ApproovService.addSubstitutionQueryParam(key: "api_key")
+
+        var request = try HTTPClient.Request(url: "\(targetURLString)?api_key=query-key", method: .GET)
+        request.headers.add(name: "Authorization", value: "Bearer oauth-token")
+        request.headers.add(name: "Api-Key", value: "header-key")
+
+        let reply = fetchNetworkReply(for: request)
+
+        let token = try XCTUnwrap(getHeader(from: reply, key: "Approov-Token"))
+        XCTAssertFalse(token.isEmpty)
+        XCTAssertNotNil(getHeader(from: reply, key: "Approov-TraceID"))
+        XCTAssertEqual(getHeader(from: reply, key: "Api-Key"), "header-secret")
+
+        let urlFromReply = try XCTUnwrap(reply?["url"] as? String)
+        XCTAssertTrue(urlFromReply.contains("api_key=query-secret"))
+
+        let payload = try XCTUnwrap(decodeJWTBody(token))
+        XCTAssertEqual(payload["pay"] as? String, sha256Base64("Bearer oauth-token"))
+    }
+
+    func testFetchTokenReturnsSignedTokenWithExpectedClaims() throws {
+        try reinitializeServiceWithTargetHost()
+        let token = try ApproovService.fetchToken(url: targetURLString)
+        let payload = try XCTUnwrap(decodeJWTBody(token))
+
+        XCTAssertEqual(payload["ip"] as? String, "81.149.55.236")
+        XCTAssertEqual(payload["did"] as? String, "daIvmEWBA2gvZny7a/RC/w==")
+        XCTAssertEqual(payload["mskid"] as? String, "j3AWy6")
+        XCTAssertEqual(payload["arc"] as? String, "IXPSB7TRK26LXE3M")
+        XCTAssertNotNil(payload["exp"] as? NSNumber)
+    }
+
+    func testUpdateRequestNoApproovServiceProceedsWithoutToken() throws {
+        try reinitializeServiceWithTargetHost()
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "NO_APPROOV_SERVICE"
+              }
+            }
+            """
+        )
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let reply = fetchNetworkReply(for: request)
+
+        XCTAssertNotNil(reply, "Expected to receive a reply from worker when proceeding without token")
+        XCTAssertNil(getHeader(from: reply, key: "Approov-Token"))
+        XCTAssertNil(getHeader(from: reply, key: "Approov-TraceID"))
+    }
+
+    func testUpdateRequestCanIgnoreExcludedURL() throws {
+        let exclusionStr = "^.*excluded.*$"
+        ApproovService.addExclusionURLRegex(urlRegex: exclusionStr)
+
+        let request = try HTTPClient.Request(url: "\(targetURLString)/excluded", method: .GET)
+        let reply = fetchNetworkReply(for: request)
+
+        XCTAssertNotNil(reply, "Expected to receive a reply even for ignored domains")
+        XCTAssertNil(getHeader(from: reply, key: "Approov-Token"))
+    }
+
+    func testFetchTokenThrowsNetworkingErrorForNoNetwork() throws {
+        try reinitializeServiceWithTargetHost()
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "NO_NETWORK"
+              }
+            }
+            """
+        )
+
+        XCTAssertThrowsError(try ApproovService.fetchToken(url: targetURLString)) { error in
+            guard case let ApproovError.networkingError(message) = error else {
+                return XCTFail("Expected networkingError, got \(error)")
+            }
+            XCTAssertEqual(message, "fetchToken network error: no network")
+        }
+    }
+
+    func testExecuteRequestSendsMutatedRequest() throws {
+        try reinitializeServiceWithTargetHost()
+        
+        let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            try? client.syncShutdown()
+        }
+        
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let response = try client.execute(request: request).wait()
+        
+        XCTAssertEqual(response.status, .ok)
+        
+        if let body = response.body {
+            let data = body.getData(at: 0, length: body.readableBytes) ?? Data()
+            let reply = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            XCTAssertNotNil(getHeader(from: reply, key: "Approov-Token"))
+            XCTAssertNotNil(getHeader(from: reply, key: "Approov-TraceID"))
+        } else {
+            XCTFail("Expected response body")
+        }
+    }
+
+    func testExecuteAsyncRequestSendsMutatedRequest() async throws {
+        try reinitializeServiceWithTargetHost()
+        
+        let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            try? client.syncShutdown()
+        }
+        
+        var request = HTTPClientRequest(url: targetURLString)
+        request.method = .GET
+        let response = try await client.execute(request, timeout: .seconds(5))
+        
+        XCTAssertEqual(response.status, .ok)
+        
+        let buffer = try await response.body.collect(upTo: 1024 * 1024)
+        let data = Data(buffer: buffer)
+        let reply = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(getHeader(from: reply, key: "Approov-Token"))
+        XCTAssertNotNil(getHeader(from: reply, key: "Approov-TraceID"))
+    }
+
+    func testSignRequestAddsTokenSubstitutionsBindingHashAndSignatureHeaders() throws {
+        let targetHost = try XCTUnwrap(URL(string: targetURLString)?.host)
+        try reinitializeService(
+            scenarioJSON: scenarioJSON(
+                caseName: uniqueCaseName(prefix: "sign-request"),
+                body: """
+                "protectedDomains": ["\(targetHost)"],
+                "initialSecureStrings": {
+                  "header-key": "header-secret",
+                  "query-key": "query-secret"
+                }
+                """
+            ),
+            comment: "reinit-sign-request"
+        )
+
+        ApproovService.bindHeader = "Authorization"
+        ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: nil)
+        ApproovService.addSubstitutionQueryParam(key: "api_key")
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseAccountMessageSigning()
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        var request = try HTTPClient.Request(url: "\(targetURLString)?api_key=query-key", method: .GET)
+        request.headers.add(name: "Authorization", value: "Bearer oauth-token")
+        request.headers.add(name: "Api-Key", value: "header-key")
+
+        let signedRequest = try ApproovService.signRequest(request)
+
+        XCTAssertTrue(signedRequest.url.absoluteString.contains("api_key=query-secret"))
+        XCTAssertEqual(signedRequest.headers.first(name: "Authorization"), "Bearer oauth-token")
+        XCTAssertEqual(signedRequest.headers.first(name: "Api-Key"), "header-secret")
+        let token = try XCTUnwrap(signedRequest.headers.first(name: "Approov-Token"))
+        XCTAssertFalse(token.isEmpty)
+        XCTAssertNotNil(signedRequest.headers.first(name: "Approov-TraceID"))
+        XCTAssertTrue(try XCTUnwrap(signedRequest.headers.first(name: "Signature-Input")).hasPrefix("account="))
+        XCTAssertTrue(try XCTUnwrap(signedRequest.headers.first(name: "Signature")).hasPrefix("account="))
+
+        let payload = try XCTUnwrap(decodeJWTBody(token))
+        XCTAssertEqual(payload["pay"] as? String, sha256Base64("Bearer oauth-token"))
+
+        let reply = fetchPlainNetworkReply(for: signedRequest)
+        XCTAssertEqual(getHeader(from: reply, key: "Api-Key"), "header-secret")
+        XCTAssertNotNil(getHeader(from: reply, key: "Approov-Token"))
+        XCTAssertNotNil(getHeader(from: reply, key: "Signature"))
+        let urlFromReply = try XCTUnwrap(reply?["url"] as? String)
+        XCTAssertTrue(urlFromReply.contains("api_key=query-secret"))
+    }
+
+    func testSignRequestReturnsOriginalRequestForIgnoredURL() throws {
+        try reinitializeServiceWithTargetHost()
+
+        var request = try HTTPClient.Request(url: unprotectedURLString, method: .GET)
+        request.headers.add(name: "X-Test", value: "original")
+
+        let signedRequest = try ApproovService.signRequest(request)
+
+        XCTAssertEqual(signedRequest.url, request.url)
+        XCTAssertEqual(signedRequest.headers.first(name: "X-Test"), "original")
+        XCTAssertNil(signedRequest.headers.first(name: "Approov-Token"))
+        XCTAssertNil(signedRequest.headers.first(name: "Approov-TraceID"))
+    }
+
+    func testSignRequestThrowsNetworkingErrorForRetryDecision() throws {
+        try reinitializeServiceWithTargetHost()
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "NO_NETWORK"
+              }
+            }
+            """
+        )
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+
+        XCTAssertThrowsError(try ApproovService.signRequest(request)) { error in
+            guard case let ApproovError.networkingError(message) = error else {
+                return XCTFail("Expected networkingError, got \(error)")
+            }
+            XCTAssertTrue(message.contains("no network"), "Unexpected message: \(message)")
+        }
+    }
+
+    func testSignRequestThrowsPermanentErrorForFailDecision() throws {
+        try reinitializeServiceWithTargetHost()
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "REJECTED"
+              }
+            }
+            """
+        )
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+
+        XCTAssertThrowsError(try ApproovService.signRequest(request)) { error in
+            guard case let ApproovError.permanentError(message) = error else {
+                return XCTFail("Expected permanentError, got \(error)")
+            }
+            XCTAssertTrue(message.contains("rejected"), "Unexpected message: \(message)")
+        }
+    }
+
+    // MARK: - §3 Service Mutators & Decision Overrides
+
+    struct AlwaysProceedMutator: ApproovServiceMutator {
+        func handleInterceptorFetchTokenResult(_ approovResults: ApproovTokenFetchResult, url: String) throws -> Bool {
+            return false // proceed without throwing
+        }
+    }
+
+    func testServiceMutatorOverridesFailClosedBehavior() throws {
+        try reinitializeServiceWithTargetHost()
+
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "MITM_DETECTED"
+              }
+            }
+            """
+        )
+
+        ApproovService.setServiceMutator(AlwaysProceedMutator())
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let reply = fetchNetworkReply(for: request)
+
+        XCTAssertNotNil(reply, "Expected to receive a reply from worker when proceeding due to overridden mutator")
+        XCTAssertNil(getHeader(from: reply, key: "Approov-Token"))
+    }
+
+    // MARK: - §4 Pinning Configuration & Scenarios
+
+    func testPinningAcceptAny() throws {
+        try reinitializeServiceWithTargetHost()
+
+        MiniSDKAttesterProxyController.setNextPinningDirectiveJSON("{\"operation\": \"getPins\", \"acceptAny\": true}")
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let reply = fetchNetworkReply(for: request)
+
+        XCTAssertNotNil(reply, "Expected the request to succeed when acceptAny is used")
+    }
+
+    func testPinningFailureTriggersPinningError() throws {
+        try reinitializeServiceWithTargetHost()
+
+        MiniSDKAttesterProxyController.setNextPinningDirectiveJSON("{\"operation\": \"getPins\", \"shouldFail\": true}")
+
+        let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            try? client.syncShutdown()
+        }
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        XCTAssertThrowsError(try client.execute(request: request).wait()) { error in
+            // Should fail with standard NIO-SSL connection aborted or TLS pinning verification failure
+            XCTAssertNotNil(error)
+        }
+    }
+
+    // MARK: - §5 Message Signing
+
+    func testUpdateRequestInstallMessageSigningAddsSignatureHeaders() throws {
+        try reinitializeServiceWithTargetHost()
+
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseInstallMessageSigning()
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let protectedReply = fetchNetworkReply(for: request)
+
+        XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-Token"))
+        let signatureInput = try XCTUnwrap(getHeader(from: protectedReply, key: "Signature-Input"))
+        XCTAssertTrue(signatureInput.hasPrefix("install="))
+        XCTAssertEqual(signatureInput.components(separatedBy: "install=").count, 2)
+        XCTAssertFalse(signatureInput.contains("account="))
+
+        let signature = try XCTUnwrap(getHeader(from: protectedReply, key: "Signature"))
+        XCTAssertTrue(signature.hasPrefix("install="))
+        XCTAssertEqual(signature.components(separatedBy: "install=").count, 2)
+        XCTAssertFalse(signature.contains("account="))
+
+        var unprotectedRequest = try HTTPClient.Request(url: unprotectedURLString, method: .GET)
+        let unprotectedReply = fetchNetworkReply(for: unprotectedRequest)
+
+        XCTAssertNil(getHeader(from: unprotectedReply, key: "Approov-Token"))
+        XCTAssertNil(getHeader(from: unprotectedReply, key: "Signature"))
+        XCTAssertNil(getHeader(from: unprotectedReply, key: "Signature-Input"))
+    }
+
+    func testUpdateRequestAccountMessageSigningAddsSignatureHeaders() throws {
+        try reinitializeServiceWithTargetHost()
+
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseAccountMessageSigning()
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let protectedReply = fetchNetworkReply(for: request)
+
+        XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-Token"))
+        let signatureInput = try XCTUnwrap(getHeader(from: protectedReply, key: "Signature-Input"))
+        XCTAssertTrue(signatureInput.hasPrefix("account="))
+        XCTAssertEqual(signatureInput.components(separatedBy: "account=").count, 2)
+        XCTAssertFalse(signatureInput.contains("install="))
+
+        let signature = try XCTUnwrap(getHeader(from: protectedReply, key: "Signature"))
+        XCTAssertTrue(signature.hasPrefix("account="))
+        XCTAssertEqual(signature.components(separatedBy: "account=").count, 2)
+        XCTAssertFalse(signature.contains("install="))
+    }
+
+    func testInstallMessageSigningFailsGracefullyIfKeyGenerationFails() throws {
+        let targetHost = try XCTUnwrap(URL(string: targetURLString)?.host)
+        let domainsJSON = "\"protectedDomains\": [\"\(targetHost)\"]"
+        try reinitializeService(
+            scenarioJSON: scenarioJSON(
+                caseName: uniqueCaseName(prefix: "no-install-key"),
+                body: domainsJSON
+            ),
+            comment: "options:no-install-key"
+        )
+
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseInstallMessageSigning()
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let protectedReply = fetchNetworkReply(for: request)
+
+        XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-Token"))
+        XCTAssertNil(getHeader(from: protectedReply, key: "Signature"))
+        XCTAssertNil(getHeader(from: protectedReply, key: "Signature-Input"))
+    }
+
+    func testDigestBodyAppendedForPOSTPUTPATCHRequests() throws {
+        try reinitializeServiceWithTargetHost()
+
+        let factory = try ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseInstallMessageSigning()
+            .setBodyDigestConfig(ApproovDefaultMessageSigning.DIGEST_SHA256, required: true)
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        for method in ["POST", "PUT", "PATCH"] {
+            var request = try HTTPClient.Request(url: targetURLString, method: HTTPMethod(rawValue: method))
+            request.body = .byteBuffer(ByteBuffer(string: "{\"test\": 1}"))
+            request.headers.add(name: "Content-Type", value: "application/json")
+
+            let protectedReply = fetchNetworkReply(for: request)
+
+            XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-Token"))
+            let signatureInput = try XCTUnwrap(getHeader(from: protectedReply, key: "Signature-Input"), "Failed on \(method)")
+            XCTAssertTrue(signatureInput.contains("content-digest"), "Signature-Input should include content-digest for \(method)")
+            XCTAssertNotNil(getHeader(from: protectedReply, key: "Content-Digest"), "Content-Digest should be generated for \(method)")
+        }
+    }
+
+    // MARK: - §6 Secure Strings & Custom JWT
+
+    func testFetchSecureStringReturnsConfiguredValue() throws {
+        setDirective(
+            """
+            {
+              "operation": "fetchSecureString",
+              "response": {
+                "status": "SUCCESS",
+                "secureString": "mini-secret"
+              }
+            }
+            """
+        )
+
+        let secureString = try ApproovService.fetchSecureString(key: "api-key", newDef: nil)
+        XCTAssertEqual(secureString, "mini-secret")
+    }
+
+    func testFetchSecureStringReturnsNilForUnknownKey() throws {
+        setDirective(
+            """
+            {
+              "operation": "fetchSecureString",
+              "response": {
+                "status": "UNKNOWN_KEY"
+              }
+            }
+            """
+        )
+
+        let secureString = try ApproovService.fetchSecureString(key: "missing-key", newDef: nil)
+        XCTAssertNil(secureString)
+    }
+
+    func testFetchSecureStringEmptyKeyRaisesPermanentError() throws {
+        XCTAssertThrowsError(try ApproovService.fetchSecureString(key: "", newDef: nil)) { error in
+            guard case let ApproovError.permanentError(message) = error else {
+                return XCTFail("Expected permanentError, got \(error)")
+            }
+            XCTAssertTrue(message.contains("bad key"), "Expected bad key message")
+        }
+    }
+
+    func testFetchCustomJWTReturnsSignedJWT() throws {
+        let jwt = try XCTUnwrap(ApproovService.fetchCustomJWT(payload: "{\"role\":\"tester\"}"))
+        let payload = try XCTUnwrap(decodeJWTBody(jwt))
+
+        XCTAssertEqual(payload["role"] as? String, "tester")
+        XCTAssertNil(payload["exp"])
+        XCTAssertNil(payload["did"])
+    }
+
+    struct CustomPayload: Codable {
+        let data: String
+    }
+
+    func testFetchCustomJWT18KBPayload() throws {
+        let largePayload = String(repeating: "A", count: 18 * 1024)
+        let payloadStruct = CustomPayload(data: largePayload)
+
+        let jsonData = try JSONEncoder().encode(payloadStruct)
+        let json = try XCTUnwrap(String(data: jsonData, encoding: .utf8))
+
+        let jwt = try XCTUnwrap(ApproovService.fetchCustomJWT(payload: json))
+        let payloadMap = try XCTUnwrap(decodeJWTBody(jwt))
+        XCTAssertEqual(payloadMap["data"] as? String, largePayload)
+    }
+
+    func testFetchCustomJWTDisabledRaisesPermanentError() throws {
+        try reinitializeService(
+            scenarioJSON: scenarioJSON(
+                caseName: uniqueCaseName(prefix: "custom-jwt-disabled"),
+                body: """
+                "customJWTEnabled": false
+                """
+            ),
+            comment: "reinit-custom-jwt-disabled"
+        )
+
+        XCTAssertThrowsError(try ApproovService.fetchCustomJWT(payload: "{\"role\":\"tester\"}")) { error in
+            guard case let ApproovError.permanentError(message) = error else {
+                return XCTFail("Expected permanentError, got \(error)")
+            }
+            XCTAssertEqual(message, "fetchCustomJWT: disabled")
+        }
+    }
+
+    func testFetchCustomJWTBadPayloadRaisesPermanentError() {
+        XCTAssertThrowsError(try ApproovService.fetchCustomJWT(payload: "not-json")) { error in
+            guard case let ApproovError.permanentError(message) = error else {
+                return XCTFail("Expected permanentError, got \(error)")
+            }
+            XCTAssertEqual(message, "fetchCustomJWT: bad payload")
+        }
+    }
+
+    // MARK: - §7 Failure Caching
+
+    func testCachedFailureShortCircuitsSDKFetchWithinTTL() throws {
+        try reinitializeServiceWithTargetHost()
+
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "NO_NETWORK"
+              }
+            }
+            """
+        )
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let appReq = ApproovRequest(url: request.url, method: request.method.rawValue, headers: request.headers, body: nil)
+        let response1 = ApproovService.updateRequestWithApproov(request: appReq)
+        XCTAssertEqual(response1.decision, .ShouldRetry)
+        XCTAssertEqual(response1.sdkMessage, "no network")
+
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "SUCCESS",
+                "token": "fresh-token-that-should-be-ignored"
+              }
+            }
+            """
+        )
+
+        let response2 = ApproovService.updateRequestWithApproov(request: appReq)
+        XCTAssertEqual(response2.decision, .ShouldRetry)
+        XCTAssertEqual(response2.sdkMessage, "no network")
+    }
+
+    func testCachedFailureShortCircuitsConcurrentRequestsWithinTTL() throws {
+        try reinitializeServiceWithTargetHost()
+
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "NO_NETWORK"
+              }
+            }
+            """
+        )
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let appReq = ApproovRequest(url: request.url, method: request.method.rawValue, headers: request.headers, body: nil)
+        let requestCount = 24
+        let startGate = DispatchSemaphore(value: 0)
+        let completionGroup = DispatchGroup()
+        let responsesLock = NSLock()
+        var responses: [ApproovUpdateResponse] = []
+
+        for _ in 0..<requestCount {
+            completionGroup.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                startGate.wait()
+                let response = ApproovService.updateRequestWithApproov(request: appReq)
+                responsesLock.lock()
+                responses.append(response)
+                responsesLock.unlock()
+                completionGroup.leave()
+            }
+        }
+
+        for _ in 0..<requestCount {
+            startGate.signal()
+        }
+
+        switch completionGroup.wait(timeout: .now() + 5.0) {
+        case .success:
+            break
+        case .timedOut:
+            XCTFail("Timed out waiting for concurrent cached-failure requests")
+            return
+        }
+
+        XCTAssertEqual(responses.count, requestCount)
+        for response in responses {
+            XCTAssertEqual(response.decision, .ShouldRetry)
+            XCTAssertEqual(response.sdkMessage, "no network")
+        }
+    }
+
+    func testCachedFailureExpiresAfterTTL() throws {
+        try reinitializeServiceWithTargetHost()
+
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "NO_NETWORK"
+              }
+            }
+            """
+        )
+
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let appReq = ApproovRequest(url: request.url, method: request.method.rawValue, headers: request.headers, body: nil)
+        let response1 = ApproovService.updateRequestWithApproov(request: appReq)
+        XCTAssertEqual(response1.decision, .ShouldRetry)
+        XCTAssertEqual(response1.sdkMessage, "no network")
+
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "SUCCESS",
+                "token": "fresh-token-after-ttl"
+              }
+            }
+            """
+        )
+
+        Thread.sleep(forTimeInterval: 1.0)
+
+        let response2 = ApproovService.updateRequestWithApproov(request: appReq)
+        XCTAssertEqual(response2.decision, .ShouldProceed)
+        XCTAssertEqual(response2.sdkMessage, "success")
+    }
+
+    // MARK: - Test Helpers
+
+    private var targetURLString: String {
+        guard let url = ProcessInfo.processInfo.environment["TESTING_REPLY_URL"] else {
+            fatalError("TESTING_REPLY_URL environment variable is not set")
+        }
+        return url
+    }
+
+    private var unprotectedURLString: String {
+        guard let url = ProcessInfo.processInfo.environment["TESTING_REPLY_URL_UNPROTECTED"] else {
+            fatalError("TESTING_REPLY_URL_UNPROTECTED environment variable is not set")
+        }
+        return url
+    }
+
+    private func fetchNetworkReply(for request: HTTPClient.Request) -> [String: Any]? {
+        let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            try? client.syncShutdown()
+        }
+        var receivedData: Data?
+        do {
+            let response = try client.execute(request: request).wait()
+            if let body = response.body {
+                receivedData = body.getData(at: 0, length: body.readableBytes)
+            }
+        } catch {
+            print("Request failed with error: \(error)")
+        }
+        guard let data = receivedData,
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return obj
+    }
+
+    private func fetchPlainNetworkReply(for request: HTTPClient.Request) -> [String: Any]? {
+        let client = HTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            try? client.syncShutdown()
+        }
+        var receivedData: Data?
+        do {
+            let response = try client.execute(request: request).wait()
+            if let body = response.body {
+                receivedData = body.getData(at: 0, length: body.readableBytes)
+            }
+        } catch {
+            print("Request failed with error: \(error)")
+        }
+        guard let data = receivedData,
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return obj
+    }
+
+    private func getHeader(from reply: [String: Any]?, key: String) -> String? {
+        guard let headers = reply?["headers"] as? [String: Any] else { return nil }
+        let lowerKey = key.lowercased()
+        let val = headers[lowerKey] ?? headers[key]
+        if let str = val as? String {
+            return str
+        }
+        if let arr = val as? [String], let first = arr.first {
+            return first
+        }
+        return nil
+    }
+
+    private func reinitializeServiceWithTargetHost(scenarioBody: String = "") throws {
+        let targetHost = try XCTUnwrap(URL(string: targetURLString)?.host)
+        let domainsJSON = "\"protectedDomains\": [\"\(targetHost)\"]"
+        let fullBody = scenarioBody.isEmpty ? domainsJSON : "\(domainsJSON), \(scenarioBody)"
+
+        try reinitializeService(
+            scenarioJSON: scenarioJSON(
+                caseName: uniqueCaseName(prefix: "target-host"),
+                body: fullBody
+            ),
+            comment: "reinit-target-host"
+        )
+    }
+
+    private func initializeService(comment: String?) throws {
+        try ApproovService.initialize(config: validInitialConfig, comment: comment)
+    }
+
+    private func reinitializeService(scenarioJSON: String? = nil, comment: String) throws {
+        MiniSDKAttesterProxyController.reset()
+        if let scenarioJSON {
+            MiniSDKAttesterProxyController.loadScenarioJSON(scenarioJSON)
+        }
+        ApproovService.resetForTesting()
+        ApproovService.loggingLevel = .off
+        try initializeService(comment: comment)
+    }
+
+    private func setDirective(_ json: String) {
+        MiniSDKAttesterProxyController.setNextAttestationDirectiveJSON(json)
+    }
+
+    private func uniqueCaseName(prefix: String) -> String {
+        "\(prefix)-\(UUID().uuidString.lowercased())"
+    }
+
+    private func scenarioJSON(caseName: String, body: String) -> String {
+        """
+        {
+          "activeCase": "\(caseName)",
+          "cases": {
+            "\(caseName)": {
+              \(body)
+            }
+          }
+        }
+        """
+    }
+
+    private func decodeJWTBody(_ jwt: String) -> [String: Any]? {
+        let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3 else {
+            return nil
+        }
+        guard let data = base64URLDecode(String(parts[1])),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return object
+    }
+
+    private func base64URLDecode(_ value: String) -> Data? {
+        var padded = value.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        padded.append(String(repeating: "=", count: (4 - padded.count % 4) % 4))
+        return Data(base64Encoded: padded)
+    }
+
+    private func sha256Base64(_ value: String) -> String {
+        Data(SHA256.hash(data: Data(value.utf8))).base64EncodedString()
+    }
+}

--- a/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -447,9 +447,15 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
     }
 
     func testPinningFailureTriggersPinningError() throws {
-        try reinitializeServiceWithTargetHost()
-
-        MiniSDKAttesterProxyController.setNextPinningDirectiveJSON("{\"operation\": \"getPins\", \"shouldFail\": true}")
+        let targetHost = try XCTUnwrap(URL(string: targetURLString)?.host)
+        try reinitializeServiceWithTargetHost(scenarioBody: """
+            "pins": {
+              "public-key-sha256": {
+                "*": ["invalid-pin-base64="],
+                "\(targetHost)": ["invalid-pin-base64="]
+              }
+            }
+            """)
 
         let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
         defer {

--- a/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -8,6 +8,7 @@ import NIOSSL
 import Approov
 import MiniSDKTestSupport
 import CryptoKit
+import NIOEmbedded
 
 /// Integration tests for the ApproovService AsyncHTTPClient service layer.
 final class ApproovServiceMiniSDKTests: XCTestCase {
@@ -466,7 +467,7 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
         XCTAssertEqual(signature.components(separatedBy: "install=").count, 2)
         XCTAssertFalse(signature.contains("account="))
 
-        var unprotectedRequest = try HTTPClient.Request(url: unprotectedURLString, method: .GET)
+        let unprotectedRequest = try HTTPClient.Request(url: unprotectedURLString, method: .GET)
         let unprotectedReply = fetchNetworkReply(for: unprotectedRequest)
 
         XCTAssertNil(getHeader(from: unprotectedReply, key: "Approov-Token"))
@@ -770,6 +771,251 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
         let response2 = ApproovService.updateRequestWithApproov(request: appReq)
         XCTAssertEqual(response2.decision, .ShouldProceed)
         XCTAssertEqual(response2.sdkMessage, "success")
+    }
+
+    func testInitializeWithEmptyConfigAfterValidConfigIsIgnored() throws {
+        // Initialized with valid config
+        try reinitializeServiceWithTargetHost()
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertTrue(ApproovService.isApproovEnabled())
+        
+        // Attempting initialize with empty config should be ignored
+        try ApproovService.initialize(config: "")
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertTrue(ApproovService.isApproovEnabled()) // Remains enabled
+    }
+
+    func testRepeatedReinitAndOptionsCommentBehavior() throws {
+        try reinitializeServiceWithTargetHost()
+        
+        // Initial setup with options: comment
+        try ApproovService.initialize(config: validInitialConfig, comment: "options:test-option")
+        XCTAssertTrue(ApproovService.isInitialized())
+        
+        // Repeated setup with reinit... comment should be forwarded and succeed
+        try ApproovService.initialize(config: validInitialConfig, comment: "reinit-options")
+        XCTAssertTrue(ApproovService.isInitialized())
+    }
+
+    func testStatePreservationAfterFailedDifferentConfigInit() throws {
+        try reinitializeServiceWithTargetHost()
+        
+        // Attempting initialize with a different non-empty config should throw and preserve state
+        XCTAssertThrowsError(try ApproovService.initialize(config: "different-config-string", comment: "reinit")) { error in
+            XCTAssertNotNil(error)
+        }
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertTrue(ApproovService.isApproovEnabled())
+    }
+
+    func testCustomTokenAndTraceHeaderNamesAndPrefixes() throws {
+        try reinitializeServiceWithTargetHost()
+        
+        ApproovService.approovTokenHeaderAndPrefix = (approovTokenHeader: "Custom-Token", approovTokenPrefix: "CustomPrefix ")
+        ApproovService.setApproovTraceIDHeader(header: "Custom-TraceID")
+        
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let protectedReply = fetchNetworkReply(for: request)
+        
+        XCTAssertNotNil(protectedReply, "Expected request to succeed")
+        let customToken = getHeader(from: protectedReply, key: "Custom-Token")
+        XCTAssertNotNil(customToken)
+        XCTAssertTrue(customToken?.hasPrefix("CustomPrefix ") ?? false)
+        XCTAssertNotNil(getHeader(from: protectedReply, key: "Custom-TraceID"))
+        
+        // Test null/nil prefix treated as empty string
+        ApproovService.approovTokenHeaderAndPrefix = (approovTokenHeader: "Custom-Token", approovTokenPrefix: "")
+        let reply2 = fetchNetworkReply(for: request)
+        let customToken2 = getHeader(from: reply2, key: "Custom-Token")
+        XCTAssertFalse(customToken2?.hasPrefix("null") ?? true)
+    }
+
+    func testMissingAndEmptyTokenAndTraceArtifacts() throws {
+        try reinitializeServiceWithTargetHost()
+        
+        class FallbackMutator: ApproovServiceMutator {
+            func handleInterceptorShouldProcessRequest(_ request: ApproovRequest) throws -> Bool { return true }
+            func handleInterceptorFetchTokenResult(_ approovResults: ApproovTokenFetchResult, url: String) throws -> Bool { return true }
+            func handleInterceptorHeaderSubstitutionResult(_ approovResults: ApproovTokenFetchResult, header: String) throws -> Bool { return true }
+            func handleInterceptorQueryParamSubstitutionResult(_ approovResults: ApproovTokenFetchResult, queryKey: String) throws -> Bool { return true }
+            func handleInterceptorProcessedRequest(_ request: ApproovRequest, changes: ApproovRequestMutations) throws -> ApproovRequest { return request }
+            func handlePinningShouldProcessRequest(hostname: String) -> Bool { return true }
+        }
+        ApproovService.setServiceMutator(FallbackMutator())
+        
+        // Set next attestation directive to yield empty token/trace with status REJECTED (so they are not overwritten)
+        MiniSDKAttesterProxyController.setNextAttestationDirectiveJSON("{\"response\": {\"status\": \"REJECTED\", \"token\": \"\", \"traceID\": \"\"}}")
+        
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let protectedReply = fetchNetworkReply(for: request)
+        
+        // Emitted headers should be empty rather than omitted
+        let token = getHeader(from: protectedReply, key: "Approov-Token")
+        let trace = getHeader(from: protectedReply, key: "Approov-TraceID")
+        XCTAssertEqual(token, "")
+        XCTAssertEqual(trace, "")
+    }
+
+    func testSubstitutionRemoval() throws {
+        try reinitializeServiceWithTargetHost()
+        
+        ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: "Bearer ")
+        ApproovService.removeSubstitutionHeader(header: "Api-Key")
+        
+        var request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        request.headers.add(name: "Api-Key", value: "Bearer placeholder-key")
+        
+        let reply = fetchNetworkReply(for: request)
+        // Original placeholder should remain since substitution was removed
+        XCTAssertEqual(getHeader(from: reply, key: "Api-Key"), "Bearer placeholder-key")
+    }
+
+    func testEmptySubstitutionValues() throws {
+        try reinitializeServiceWithTargetHost()
+        
+        ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: "")
+        
+        // Load scenario where key lookup yields empty secure string
+        MiniSDKAttesterProxyController.setNextAttestationDirectiveJSON("{\"status\": \"SUCCESS\", \"secureString\": \"\"}")
+        
+        var request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        request.headers.add(name: "Api-Key", value: "placeholder-key")
+        
+        let reply = fetchNetworkReply(for: request)
+        // Original placeholder should remain intact if lookup is empty
+        XCTAssertEqual(getHeader(from: reply, key: "Api-Key"), "placeholder-key")
+    }
+
+    func testUnprotectedExcludedPinningBehavior() throws {
+        try reinitializeServiceWithTargetHost()
+        
+        // Add exclusion for matching endpoint
+        ApproovService.addExclusionURLRegex(urlRegex: ".*/excluded")
+        
+        // Verify pinning still active for host even if URL is excluded from token injection
+        MiniSDKAttesterProxyController.setNextPinningDirectiveJSON("{\"operation\": \"getPins\", \"shouldFail\": true}")
+        
+        let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            try? client.syncShutdown()
+        }
+        let request = try HTTPClient.Request(url: "\(targetURLString)/excluded", method: .GET)
+        XCTAssertThrowsError(try client.execute(request: request).wait()) { error in
+            XCTAssertNotNil(error)
+        }
+    }
+
+    func testAsyncBodyDigestBehavior() async throws {
+        try reinitializeServiceWithTargetHost()
+        
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseInstallMessageSigning()
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+        
+        var request = HTTPClientRequest(url: targetURLString)
+        request.method = .POST
+        request.body = .bytes(ByteBuffer(string: "test-async-body"))
+        
+        let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            try? client.syncShutdown()
+        }
+        let response = try await client.execute(request, timeout: .seconds(5))
+        
+        // Consume response
+        var body = try await response.body.collect(upTo: 1024 * 1024)
+        guard let data = body.readData(length: body.readableBytes),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let headers = obj["headers"] as? [String: Any] else {
+            XCTFail("Failed to parse response body")
+            return
+        }
+        
+        XCTAssertNotNil(headers["content-digest"])
+        XCTAssertNotNil(headers["signature"])
+    }
+
+    func testUnsupportedSigningAlgorithms() throws {
+        try reinitializeServiceWithTargetHost()
+        
+        class UnsupportedAlgFactory: SignatureParametersFactory {
+            override func buildSignatureParameters(provider: ApproovAsyncHTTPClientComponentProvider, changes: ApproovRequestMutations) throws -> SignatureParameters {
+                let params = try super.buildSignatureParameters(provider: provider, changes: changes)
+                params.setAlg("unsupported-alg")
+                return params
+            }
+        }
+        
+        let factory = UnsupportedAlgFactory()
+            .setUseInstallMessageSigning()
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+        
+        let request = try HTTPClient.Request(url: targetURLString, method: .GET)
+        let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            try? client.syncShutdown()
+        }
+        XCTAssertThrowsError(try client.execute(request: request).wait()) { error in
+            XCTAssertNotNil(error)
+        }
+    }
+
+    func testASN1DecodeFailures() throws {
+        // Test various invalid ASN.1 DER structures directly to verify bounds checking
+        let tooShort = Data([0x30])
+        XCTAssertThrowsError(try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(tooShort))
+        
+        let invalidSequenceTag = Data([0x02, 0x01, 0x00])
+        XCTAssertThrowsError(try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(invalidSequenceTag))
+        
+        let invalidSequenceLength = Data([0x30, 0x05, 0x02, 0x01, 0x00])
+        XCTAssertThrowsError(try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(invalidSequenceLength))
+        
+        let truncatedR = Data([0x30, 0x02, 0x02, 0x01])
+        XCTAssertThrowsError(try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(truncatedR))
+        
+        let invalidRTag = Data([0x30, 0x04, 0x03, 0x01, 0x00, 0x02])
+        XCTAssertThrowsError(try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(invalidRTag))
+        
+        let truncatedRValue = Data([0x30, 0x04, 0x02, 0x05, 0x01, 0x02])
+        XCTAssertThrowsError(try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(truncatedRValue))
+        
+        let truncatedS = Data([0x30, 0x06, 0x02, 0x01, 0x00, 0x02, 0x01])
+        XCTAssertThrowsError(try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(truncatedS))
+    }
+
+    func testMessageSerializationFailures() throws {
+        try reinitializeServiceWithTargetHost()
+        
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseInstallMessageSigning()
+        // Force a required body digest but provide a non-repeatable stream body that cannot be digested
+        _ = try? factory.setBodyDigestConfig("sha-256", required: true)
+        
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+        
+        // Create a non-repeatable stream body
+        var called = false
+        let requestBody = HTTPClient.Body.stream(length: 10) { writer in
+            if called {
+                return EmbeddedEventLoop().makeFailedFuture(ApproovError.permanentError(message: "Stream exhausted"))
+            }
+            called = true
+            return writer.write(.byteBuffer(ByteBuffer(string: "non-repeat")))
+        }
+        
+        let request = try HTTPClient.Request(url: targetURLString, method: .POST, body: requestBody)
+        let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            try? client.syncShutdown()
+        }
+        
+        XCTAssertThrowsError(try client.execute(request: request).wait()) { error in
+            XCTAssertNotNil(error)
+        }
     }
 
     // MARK: - Test Helpers

--- a/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -1066,33 +1066,36 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
 
     func testMessageSerializationFailures() throws {
         try reinitializeServiceWithTargetHost()
-        
+
         let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
             .setUseInstallMessageSigning()
-        // Force a required body digest but provide a non-repeatable stream body that cannot be digested
+        // Require a body digest, then provide a one-shot streaming body that the service layer cannot
+        // buffer. The required digest must fail closed during request processing.
         _ = try? factory.setBodyDigestConfig("sha-256", required: true)
-        
+
         let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
         ApproovService.setServiceMutator(signer)
-        
-        // Create a non-repeatable stream body
-        var called = false
-        let requestBody = HTTPClient.Body.stream(length: 10) { writer in
-            if called {
-                return EmbeddedEventLoop().makeFailedFuture(ApproovError.permanentError(message: "Stream exhausted"))
-            }
-            called = true
-            return writer.write(.byteBuffer(ByteBuffer(string: "non-repeat")))
+
+        // A chunked/one-shot streaming body (no declared length) is not buffered by body extraction, so
+        // a required Content-Digest cannot be produced and signing must fail closed at request-processing
+        // time — before the request is ever sent. The stream closure writes via the provided writer
+        // (never returning a future from an undriven EmbeddedEventLoop); here it is not invoked at all
+        // because the body is intentionally skipped.
+        let requestBody = HTTPClient.Body.stream(length: nil) { writer in
+            writer.write(.byteBuffer(ByteBuffer(string: "non-repeat")))
         }
-        
+
         let request = try HTTPClient.Request(url: targetURLString, method: .POST, body: requestBody)
         let client = ApproovHTTPClient(eventLoopGroupProvider: .createNew)
         defer {
             try? client.syncShutdown()
         }
-        
+
         XCTAssertThrowsError(try client.execute(request: request).wait()) { error in
-            XCTAssertNotNil(error)
+            guard case ApproovError.permanentError = error else {
+                XCTFail("Expected ApproovError.permanentError for a required digest that cannot be created, got \(error)")
+                return
+            }
         }
     }
 

--- a/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovAsyncHTTPClientMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -175,6 +175,26 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
         XCTAssertNotNil(payload["exp"] as? NSNumber)
     }
 
+    func testFetchTokenWrapsNonApproovMutatorErrorAsApproovError() throws {
+        // A custom mutator may throw an arbitrary Error; the public fetchToken contract documents
+        // ApproovError, so such errors must be wrapped rather than escaping as a foreign type.
+        struct CustomMutatorError: Error {}
+        struct ThrowingMutator: ApproovServiceMutator {
+            func handleFetchTokenResult(_ approovResults: ApproovTokenFetchResult) throws {
+                throw CustomMutatorError()
+            }
+        }
+        try reinitializeServiceWithTargetHost()
+        ApproovService.setServiceMutator(ThrowingMutator())
+
+        XCTAssertThrowsError(try ApproovService.fetchToken(url: targetURLString)) { error in
+            guard case ApproovError.permanentError = error else {
+                XCTFail("Expected ApproovError.permanentError, got \(type(of: error)): \(error)")
+                return
+            }
+        }
+    }
+
     func testUpdateRequestNoApproovServiceProceedsWithoutToken() throws {
         try reinitializeServiceWithTargetHost()
         setDirective(

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,28 +1,29 @@
 # Usage
 
-This document describes the features and functionality of the Approov Service for AsyncHTTPClient. It explains how to initialize the service, use the `ApproovHTTPClient` wrapper for protected requests, and configure optional features such as token binding, secure string substitution, exclusion rules, and direct SDK helper calls. For a basic integration example, please refer to the [Quickstart guide](https://github.com/approov/quickstart-ios-swift-asynchttpclient).
+This document describes the features and functionality of the Approov Service for AsyncHTTPClient. It explains how to initialize the service, use the `ApproovHTTPClient` wrapper for protected requests, and configure optional features such as token binding, secure string substitution, exclusion rules, custom service mutators, and HTTP message signing. For a basic integration example, please refer to the [Quickstart guide](https://github.com/approov/quickstart-ios-swift-asynchttpclient).
 
 ## Swift Package Manager Import
 
 ```swift
 import ApproovAsyncHTTPClient
-import Approov
 ```
 
 ## Basic Integration
 
-For most integrations you initialize `ApproovService` once at app startup and then create an `ApproovHTTPClient` for your protected HTTP traffic.
+For most integrations, you initialize `ApproovService` once at app startup and then create an `ApproovHTTPClient` for your protected HTTP traffic.
 
 ```swift
 import ApproovAsyncHTTPClient
 import AsyncHTTPClient
 import NIOPosix
 
+// Initialize the Approov service
 try ApproovService.initialize(config: "<config-string>")
 
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let client = ApproovHTTPClient(eventLoopGroupProvider: .shared(group))
 
+// Perform a request - Approov token, substitutions, and pinning are applied automatically
 let response = try client.get(url: "https://api.example.com/hello").wait()
 print(response.status)
 
@@ -32,155 +33,178 @@ try group.syncShutdownGracefully()
 
 The wrapper automatically applies Approov token fetching, secure string substitutions, and dynamic pinning to requests it processes.
 
-## Manual Request Protection
+## Empty Config Initialization
 
-If you need lower-level control, you can update a URL and headers yourself before sending the request through your own AsyncHTTPClient flow.
+You can initialize the `ApproovService` with an empty configuration string if you want to use the service layer without active Approov protection. This is useful when you want to bypass Approov processing (e.g., during development or testing against local staging environments).
 
 ```swift
-import ApproovAsyncHTTPClient
-import NIOHTTP1
-
-let url = URL(string: "https://api.example.com/v1/data?api_key=api-key-placeholder")!
-var headers = HTTPHeaders()
-headers.add(name: "Api-Key", value: "api-key-placeholder")
-
-let (updatedURL, updatedHeaders) = try ApproovService.updateRequest(url: url, headers: headers)
+// Initialize with an empty string to operate in bypass mode
+try? ApproovService.initialize(config: "")
 ```
 
-`updateRequest(url:headers:)` is a blocking call and should not be made on the main/UI thread.
+When initialized with an empty configuration, the service layer operates as a plain pass-through. It will not perform token injection, message signing, secure string substitution, or dynamic pinning. You can enable full Approov protection later in the application lifecycle by calling `ApproovService.initialize(config: config)` with a valid configuration string.
+
+---
+
+# Approov Service Mutator
+
+The `ApproovServiceMutator` protocol allows you to customize the behavior of the Approov service layer at key points in the request lifecycle. By implementing a custom mutator, you can override specific methods to tailor the handling of attestations, network failures, and requests while retaining the default behavior for other cases.
+
+## Why Use a Mutator?
+
+- Centralize app-specific policy without modifying the library source code.
+- Add telemetry/logging on rejections or network failures.
+- Skip Approov processing for specific hosts or endpoints.
+- Customize pinning decisions per request.
+- Adjust behavior when token or secure string fetches fail.
+- Implement HTTP message signing.
 
 ## Default Behavior
 
-By default, the `ApproovService` processes requests based on the attestation status returned by the SDK. A successful fetch adds the configured Approov token header, and secure string substitutions are applied only when it is safe to continue.
+By default, the `ApproovService` processes requests based on the attestation status. The default behavior is summarized in the table below:
 
 | Approov Fetch Status | Action | Result |
 | :--- | :--- | :--- |
 | **Success** | Proceed | The request is sent with the configured Approov token header. |
-| **No Network / Poor Network / MitM Detected** | Throw Exception | An `ApproovError.networkingError` is thrown unless `proceedOnNetworkFail` is enabled. |
-| **No Approov Service / Unknown URL / Unprotected URL** | Proceed | The request is sent without an Approov token. |
-| **Rejected / Other Permanent Errors** | Throw Exception | An `ApproovError.rejectionError` or `ApproovError.permanentError` is thrown. |
+| **No Network / Poor Network / MITM Detected** | Throw Exception | An `ApproovError.networkingError` is thrown. The request is marked as `.ShouldRetry`. |
+| **Rejection** | Throw Exception | An `ApproovError.rejectionError` is thrown. The request is marked as `.ShouldFail`. |
+| **No Approov Service / Unknown URL** | Proceed | The request is sent **without** an `Approov-Token`. |
 
-## Multiple Service Layers
+## Customizing Request Handling with Mutators
 
-It is possible to use more than one Approov service layer in the same app, for example the AsyncHTTPClient and URLSession packages together. The underlying Approov SDK can only be initialized once, so if another service layer later calls `ApproovService.initialize(...)` with the same configuration, the duplicate SDK initialization is detected and ignored.
+You may want to modify this behavior to suit specific app requirements. A common use case is handling network failures or enforcing strict token presence.
 
-In that case you may see a log entry similar to:
+### Example: Enforcing Token Presence (Block on NO_APPROOV_SERVICE)
 
-```text
-ApproovService: Ignoring initialization error in Approov SDK: The operation couldn’t be completed. (Foundation._GenericObjCError error 0.)
-```
-
-This log is informational only. Execution continues and this condition is not surfaced as an exception. If a later initialization attempts to use a different configuration, that is still treated as a real configuration error.
-
-## Reinitialization with a Comment
-
-If you call `ApproovService.initialize(config:comment:)` with a non-`nil` comment, the service layer allows the initialization call to reach the underlying SDK again. This is useful for SDK options such as comments beginning with `reinit:` that trigger internal SDK reconfiguration.
-
-```swift
-try ApproovService.initialize(config: "<config-string>", comment: "reinit:example-option")
-```
-
-## Proceed on Network Failure
-
-By default, transient network issues prevent the protected request from being sent because the app cannot safely obtain a token or secure strings. If you prefer to let requests continue without the Approov token in those cases, set:
-
-```swift
-ApproovService.proceedOnNetworkFail = true
-```
-
-Use this with caution because it may allow traffic to proceed before dynamic pins have been refreshed.
-
-## Token Binding
-
-[Token Binding](https://ext.approov.io/docs/latest/approov-usage-documentation/#token-binding) allows you to bind the Approov token to a specific header value, such as an OAuth token or session identifier.
-
-```swift
-ApproovService.bindHeader = "Authorization"
-```
-
-If the binding header value changes, the SDK automatically invalidates the previous Approov token and fetches a new one on the next protected request.
-
-## Custom Approov Token Header
-
-By default, the token is added as `Approov-Token` with no prefix. You can override both the header name and an optional prefix.
-
-```swift
-ApproovService.approovTokenHeaderAndPrefix = (
-    approovTokenHeader: "Authorization",
-    approovTokenPrefix: "Bearer "
-)
-```
-
-## Secure String Header Substitution
-
-Header substitution lets you use placeholder values in headers and have them replaced with secure strings fetched from Approov.
-
-```swift
-ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: nil)
-ApproovService.addSubstitutionHeader(header: "Authorization", prefix: "Bearer ")
-```
-
-Once configured, any matching header value is treated as a secure string lookup key.
-
-## Secure String Query Parameter Substitution
-
-Query parameter substitution works similarly for URL query values.
-
-```swift
-ApproovService.addSubstitutionQueryParam(key: "api_key")
-```
-
-For example, a request like `https://api.example.com?api_key=my-placeholder` can have `my-placeholder` replaced with the secure string value returned by Approov.
-
-## Exclusion URL Regexes
-
-You can exclude selected URLs from all Approov processing.
-
-```swift
-ApproovService.addExclusionURLRegex(urlRegex: "^https://example\.com/public/.*$")
-```
-
-This should be used with extreme caution because excluded requests do not create a path for refreshing dynamic pins.
-
-## Dynamic Pinning
-
-Dynamic certificate pinning is enabled automatically during `ApproovService.initialize(...)`. The service layer installs `ApproovPinningVerifier.verifyPinning` into AsyncHTTPClient's TLS configuration so protected hosts can be verified against the latest Approov-managed pins.
-
-For advanced integrations, the verifier is also available directly if you need to wire it into custom TLS handling.
-
-## Direct SDK Helper Calls
-
-The service layer also exposes direct helper methods for specific workflows:
-
-- `try ApproovService.precheck()` to see whether the current app instance is likely to pass attestation.
-- `let token = try ApproovService.fetchToken(url: "https://api.example.com")` when you need a token outside the normal request flow.
-- `let value = try ApproovService.fetchSecureString(key: "api-key", newDef: nil)` to fetch or define secure strings.
-- `let jwt = try ApproovService.fetchCustomJWT(payload: "{\"claim\":true}")` to fetch a custom JWT.
-- `let signature = try ApproovService.getMessageSignature(message: "example-message")` for account message signing when enabled in the Approov account.
-- `let arc = ApproovService.getLastARC()` to retrieve the last Attestation Response Code when meaningful.
-
-## Real-World Pattern
-
-A common pattern is to initialize once, configure binding and substitutions, and then reuse a single `ApproovHTTPClient` instance for all protected traffic.
+The default behavior for statuses like `NO_APPROOV_SERVICE` is to proceed with the request without adding an Approov token. If you want to ensure that *only* requests with valid proof of attestation reach your backend API, you can enforce this with a custom mutator:
 
 ```swift
 import ApproovAsyncHTTPClient
-import AsyncHTTPClient
-import NIOHTTP1
-import NIOPosix
+import Approov
 
-try ApproovService.initialize(config: "<config-string>")
-ApproovService.bindHeader = "Authorization"
-ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: nil)
-ApproovService.addSubstitutionQueryParam(key: "api_key")
+final class EnforceTokenMutator: ApproovServiceMutator {
+    func handleInterceptorFetchTokenResult(_ approovResults: ApproovTokenFetchResult, url: String) throws -> Bool {
+        // If the service is not available, do not proceed.
+        // We throw a networking error to trigger a retry.
+        if approovResults.status == .noApproovService {
+            throw ApproovError.networkingError(message: "Approov service unavailable. Will attempt connection again.")
+        }
 
-let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-let client = ApproovHTTPClient(eventLoopGroupProvider: .shared(group))
+        // For all other statuses, use the default behavior.
+        return try ApproovServiceMutatorDefault.shared.handleInterceptorFetchTokenResult(approovResults, url: url)
+    }
+}
 
-var request = try HTTPClient.Request(url: "https://api.example.com/v1/data?api_key=my-key", method: .GET)
-request.headers.add(name: "Authorization", value: "Bearer <oauth-token>")
-request.headers.add(name: "Api-Key", value: "my-key")
-
-let response = try client.execute(request: request).wait()
-print(response.status)
+// Install the mutator
+ApproovService.setServiceMutator(EnforceTokenMutator())
 ```
+
+### Example: Customizing Requests (Add Metadata Headers)
+
+You can override `handleInterceptorProcessedRequest` to add additional headers or modify the request after Approov has processed it.
+
+```swift
+final class MyMutator: ApproovServiceMutator {
+    func handleInterceptorProcessedRequest(_ request: ApproovRequest,
+                                           changes: ApproovRequestMutations) throws -> ApproovRequest {
+        var req = request
+        req.headers.replaceOrAdd(name: "Client-Platform", value: "ios")
+        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            req.headers.replaceOrAdd(name: "App-Version", value: version)
+        }
+        return req
+    }
+}
+```
+
+---
+
+# Message Signing
+
+It is possible to sign HTTP requests using Approov to ensure message integrity and authenticity. There are two types of message signing available:
+
+1.  **Installation Message Signing**: Uses an installation-specific key (held in the device's Secure Enclave) to sign requests. This provides strong non-repudiation as the signing key is unique to that specific installation and never leaves the device.
+2.  **Account Message Signing**: Uses a shared account-specific secret key (HMAC-SHA256) to sign requests. This key is delivered to the SDK only upon successful attestation.
+
+By default, the `ApproovService` uses the class `ApproovServiceMutatorDefault`, which does no message signing. Even if you install `ApproovDefaultMessageSigning`, a signature is only added when:
+- The request already has an `Approov-Token` header.
+- A `SignatureParametersFactory` is configured (default or host-specific).
+
+## Enable Message Signing with Default Settings
+
+```swift
+let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+ApproovService.setServiceMutator(signer)
+```
+
+## Custom Message Signing Parameters
+
+```swift
+let factory = SignatureParametersFactory()
+    .setUseAccountMessageSigning() // or setUseInstallMessageSigning()
+    .setAddCreated(true)
+    .setExpiresLifetime(60)
+
+let signer = ApproovDefaultMessageSigning()
+    .setDefaultFactory(factory)
+    .putHostFactory(hostName: "api.example.com", factory: factory)
+
+ApproovService.setServiceMutator(signer)
+```
+
+---
+
+# Token Binding
+
+Token Binding allows you to bind the Approov token to a specific piece of data, such as an OAuth token or a user session identifier.
+
+```swift
+// Bind the Approov token to the Authorization header
+ApproovService.bindHeader = "Authorization"
+```
+
+If the value of the binding header changes (e.g., a new OAuth token is received), the SDK automatically invalidates the current Approov token and fetches a new one with the updated binding on the next request.
+
+---
+
+# Use Approov Status as Token
+
+If an actual token cannot be obtained, you can configure the service to send the Approov fetch status (e.g., `NO_NETWORK`, `MITM_DETECTED`, `NO_APPROOV_SERVICE`) as the token header value. This allows your backend to distinguish between different failure reasons.
+
+```swift
+// Enable status-as-token injection
+ApproovService.setUseApproovStatusIfNoToken(shouldUse: true)
+```
+
+To ensure the request actually proceeds to the backend on these failure paths, you must use a custom `ApproovServiceMutator` that returns `true` for these statuses:
+
+```swift
+final class StatusAsTokenMutator: ApproovServiceMutator {
+    func handleInterceptorFetchTokenResult(_ approovResults: ApproovTokenFetchResult, url: String) throws -> Bool {
+        let status = approovResults.status
+        if status == .mitmDetected || status == .noApproovService || status == .success {
+            return true
+        }
+        return try ApproovServiceMutatorDefault.shared.handleInterceptorFetchTokenResult(approovResults, url: url)
+    }
+}
+ApproovService.setServiceMutator(StatusAsTokenMutator())
+```
+
+---
+
+# Logging
+
+You can customize the log level emitted by the `ApproovService` using the static property `loggingLevel`:
+
+```swift
+ApproovService.loggingLevel = .debug
+```
+
+Available levels are:
+*   `.off`: Disables all logging from the `ApproovService` package.
+*   `.error`: Only logs critical errors.
+*   `.warning`: Logs warnings and errors.
+*   `.info` (Default): Logs informative events, configuration receipts, and token states.
+*   `.debug`: Logs highly verbose tracing information.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,186 @@
+# Usage
+
+This document describes the features and functionality of the Approov Service for AsyncHTTPClient. It explains how to initialize the service, use the `ApproovHTTPClient` wrapper for protected requests, and configure optional features such as token binding, secure string substitution, exclusion rules, and direct SDK helper calls. For a basic integration example, please refer to the [Quickstart guide](https://github.com/approov/quickstart-ios-swift-asynchttpclient).
+
+## Swift Package Manager Import
+
+```swift
+import ApproovAsyncHTTPClient
+import Approov
+```
+
+## Basic Integration
+
+For most integrations you initialize `ApproovService` once at app startup and then create an `ApproovHTTPClient` for your protected HTTP traffic.
+
+```swift
+import ApproovAsyncHTTPClient
+import AsyncHTTPClient
+import NIOPosix
+
+try ApproovService.initialize(config: "<config-string>")
+
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+let client = ApproovHTTPClient(eventLoopGroupProvider: .shared(group))
+
+let response = try client.get(url: "https://api.example.com/hello").wait()
+print(response.status)
+
+try client.syncShutdown()
+try group.syncShutdownGracefully()
+```
+
+The wrapper automatically applies Approov token fetching, secure string substitutions, and dynamic pinning to requests it processes.
+
+## Manual Request Protection
+
+If you need lower-level control, you can update a URL and headers yourself before sending the request through your own AsyncHTTPClient flow.
+
+```swift
+import ApproovAsyncHTTPClient
+import NIOHTTP1
+
+let url = URL(string: "https://api.example.com/v1/data?api_key=api-key-placeholder")!
+var headers = HTTPHeaders()
+headers.add(name: "Api-Key", value: "api-key-placeholder")
+
+let (updatedURL, updatedHeaders) = try ApproovService.updateRequest(url: url, headers: headers)
+```
+
+`updateRequest(url:headers:)` is a blocking call and should not be made on the main/UI thread.
+
+## Default Behavior
+
+By default, the `ApproovService` processes requests based on the attestation status returned by the SDK. A successful fetch adds the configured Approov token header, and secure string substitutions are applied only when it is safe to continue.
+
+| Approov Fetch Status | Action | Result |
+| :--- | :--- | :--- |
+| **Success** | Proceed | The request is sent with the configured Approov token header. |
+| **No Network / Poor Network / MitM Detected** | Throw Exception | An `ApproovError.networkingError` is thrown unless `proceedOnNetworkFail` is enabled. |
+| **No Approov Service / Unknown URL / Unprotected URL** | Proceed | The request is sent without an Approov token. |
+| **Rejected / Other Permanent Errors** | Throw Exception | An `ApproovError.rejectionError` or `ApproovError.permanentError` is thrown. |
+
+## Multiple Service Layers
+
+It is possible to use more than one Approov service layer in the same app, for example the AsyncHTTPClient and URLSession packages together. The underlying Approov SDK can only be initialized once, so if another service layer later calls `ApproovService.initialize(...)` with the same configuration, the duplicate SDK initialization is detected and ignored.
+
+In that case you may see a log entry similar to:
+
+```text
+ApproovService: Ignoring initialization error in Approov SDK: The operation couldn’t be completed. (Foundation._GenericObjCError error 0.)
+```
+
+This log is informational only. Execution continues and this condition is not surfaced as an exception. If a later initialization attempts to use a different configuration, that is still treated as a real configuration error.
+
+## Reinitialization with a Comment
+
+If you call `ApproovService.initialize(config:comment:)` with a non-`nil` comment, the service layer allows the initialization call to reach the underlying SDK again. This is useful for SDK options such as comments beginning with `reinit:` that trigger internal SDK reconfiguration.
+
+```swift
+try ApproovService.initialize(config: "<config-string>", comment: "reinit:example-option")
+```
+
+## Proceed on Network Failure
+
+By default, transient network issues prevent the protected request from being sent because the app cannot safely obtain a token or secure strings. If you prefer to let requests continue without the Approov token in those cases, set:
+
+```swift
+ApproovService.proceedOnNetworkFail = true
+```
+
+Use this with caution because it may allow traffic to proceed before dynamic pins have been refreshed.
+
+## Token Binding
+
+[Token Binding](https://ext.approov.io/docs/latest/approov-usage-documentation/#token-binding) allows you to bind the Approov token to a specific header value, such as an OAuth token or session identifier.
+
+```swift
+ApproovService.bindHeader = "Authorization"
+```
+
+If the binding header value changes, the SDK automatically invalidates the previous Approov token and fetches a new one on the next protected request.
+
+## Custom Approov Token Header
+
+By default, the token is added as `Approov-Token` with no prefix. You can override both the header name and an optional prefix.
+
+```swift
+ApproovService.approovTokenHeaderAndPrefix = (
+    approovTokenHeader: "Authorization",
+    approovTokenPrefix: "Bearer "
+)
+```
+
+## Secure String Header Substitution
+
+Header substitution lets you use placeholder values in headers and have them replaced with secure strings fetched from Approov.
+
+```swift
+ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: nil)
+ApproovService.addSubstitutionHeader(header: "Authorization", prefix: "Bearer ")
+```
+
+Once configured, any matching header value is treated as a secure string lookup key.
+
+## Secure String Query Parameter Substitution
+
+Query parameter substitution works similarly for URL query values.
+
+```swift
+ApproovService.addSubstitutionQueryParam(key: "api_key")
+```
+
+For example, a request like `https://api.example.com?api_key=my-placeholder` can have `my-placeholder` replaced with the secure string value returned by Approov.
+
+## Exclusion URL Regexes
+
+You can exclude selected URLs from all Approov processing.
+
+```swift
+ApproovService.addExclusionURLRegex(urlRegex: "^https://example\.com/public/.*$")
+```
+
+This should be used with extreme caution because excluded requests do not create a path for refreshing dynamic pins.
+
+## Dynamic Pinning
+
+Dynamic certificate pinning is enabled automatically during `ApproovService.initialize(...)`. The service layer installs `ApproovPinningVerifier.verifyPinning` into AsyncHTTPClient's TLS configuration so protected hosts can be verified against the latest Approov-managed pins.
+
+For advanced integrations, the verifier is also available directly if you need to wire it into custom TLS handling.
+
+## Direct SDK Helper Calls
+
+The service layer also exposes direct helper methods for specific workflows:
+
+- `try ApproovService.precheck()` to see whether the current app instance is likely to pass attestation.
+- `let token = try ApproovService.fetchToken(url: "https://api.example.com")` when you need a token outside the normal request flow.
+- `let value = try ApproovService.fetchSecureString(key: "api-key", newDef: nil)` to fetch or define secure strings.
+- `let jwt = try ApproovService.fetchCustomJWT(payload: "{\"claim\":true}")` to fetch a custom JWT.
+- `let signature = try ApproovService.getMessageSignature(message: "example-message")` for account message signing when enabled in the Approov account.
+- `let arc = ApproovService.getLastARC()` to retrieve the last Attestation Response Code when meaningful.
+
+## Real-World Pattern
+
+A common pattern is to initialize once, configure binding and substitutions, and then reuse a single `ApproovHTTPClient` instance for all protected traffic.
+
+```swift
+import ApproovAsyncHTTPClient
+import AsyncHTTPClient
+import NIOHTTP1
+import NIOPosix
+
+try ApproovService.initialize(config: "<config-string>")
+ApproovService.bindHeader = "Authorization"
+ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: nil)
+ApproovService.addSubstitutionQueryParam(key: "api_key")
+
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+let client = ApproovHTTPClient(eventLoopGroupProvider: .shared(group))
+
+var request = try HTTPClient.Request(url: "https://api.example.com/v1/data?api_key=my-key", method: .GET)
+request.headers.add(name: "Authorization", value: "Bearer <oauth-token>")
+request.headers.add(name: "Api-Key", value: "my-key")
+
+let response = try client.execute(request: request).wait()
+print(response.status)
+```

--- a/USAGE.md
+++ b/USAGE.md
@@ -17,8 +17,15 @@ import ApproovAsyncHTTPClient
 import AsyncHTTPClient
 import NIOPosix
 
-// Initialize the Approov service
-try ApproovService.initialize(config: "<config-string>")
+// Initialize the Approov service. Initialization can fail (bad config / SDK error), so guard it
+// and fall back to bypass mode (empty config) rather than letting the app crash. See the README
+// "INITIALIZING APPROOV SERVICE" section for the full pattern (device-ID + session correlation logging).
+do {
+    try ApproovService.initialize(config: "<config-string>")
+} catch {
+    // Continue UNPROTECTED — requests go out without Approov protection; the backend stays the enforcement point.
+    try? ApproovService.initialize(config: "")
+}
 
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let client = ApproovHTTPClient(eventLoopGroupProvider: .shared(group))


### PR DESCRIPTION
### Purpose
Aligns the `AsyncHTTPClient` service layer with the organizational message signing fail-open policy (§5 of the testing requirements) and implements automated version tracking.

### Changes
* **Fail-Open for Decoding Failures**: Updated [ApproovDefaultMessageSigning.swift](file:///Users/ivol/Github/approov-service-ios-swift-asynchttpclient/Sources/ApproovAsyncHTTPClient/ApproovDefaultMessageSigning.swift) to gracefully fail-open, log at error level, and proceed unsigned if:
  * Base64 decoding of the signature returned by the SDK fails.
  * ASN.1/DER parsing of the signature fails (e.g. sequence format validation, integer conversions).
* **Fail-Closed Retention**: Retained fail-closed logic where appropriate:
  * Required body digests (`required = true`) that cannot be generated.
  * Unsupported signing algorithm configurations.
* **Version Tracking**: Captured the service version from the `CHANGELOG.md` (currently `3.5.4`) and appended it as a suffix (`/3.5.4`) to the `setUserProperty` call in `ApproovService.swift` so the active version is visible in server logs.
* **Automated Tag Release Workflows**: Configured the GitHub Actions workflow in `.github/workflows/build_and_test.yml` to automatically verify version consistency between `CHANGELOG.md` and `ApproovService.swift` on PR merge to `main` (push to `main`), and automatically create/push the corresponding git tag.

### Verification
* Built and ran all Swift Package Manager tests successfully (`swift test`).
* Corrected mock SDK pinning behavior in test `testPinningFailureTriggersPinningError` to prevent connection retries from bypassing transient pinning directives.

### Related Task
* Relates to: approov/core-project-approov#564
* Part of: approov/core-project-approov#352
